### PR TITLE
fix: allow replacement in replaceInfinitesFromPreviousPlayhead SUPERFLY-6

### DIFF
--- a/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
@@ -384,7 +384,8 @@ export class PlayoutPartInstanceModelImpl implements PlayoutPartInstanceModel {
 		}
 
 		for (const pieceInstance of pieceInstances) {
-			if (this.pieceInstancesImpl.has(pieceInstance._id))
+			const existingPieceInstance = this.pieceInstancesImpl.get(pieceInstance._id)
+			if (existingPieceInstance)
 				throw new Error(
 					`Cannot replace infinite PieceInstance "${pieceInstance._id}" as it replaces a non-infinite`
 				)

--- a/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutPartInstanceModelImpl.spec.ts
+++ b/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutPartInstanceModelImpl.spec.ts
@@ -1,0 +1,110 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import { getRandomId, literal } from '@sofie-automation/corelib/dist/lib'
+import { PlayoutPartInstanceModelImpl } from '../PlayoutPartInstanceModelImpl'
+import { PieceInstance, PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { IBlueprintPieceType, PieceLifespan } from '@sofie-automation/blueprints-integration'
+
+describe('PlayoutPartInstanceModelImpl', () => {
+	function createBasicDBPartInstance(): DBPartInstance {
+		return {
+			_id: getRandomId(),
+			rundownId: protectString(''),
+			segmentId: protectString(''),
+			playlistActivationId: protectString(''),
+			segmentPlayoutId: protectString(''),
+			rehearsal: false,
+
+			takeCount: 0,
+
+			part: {
+				_id: getRandomId(),
+				_rank: 0,
+				rundownId: protectString(''),
+				segmentId: protectString(''),
+				externalId: '',
+				title: '',
+
+				expectedDurationWithPreroll: undefined,
+			},
+		}
+	}
+
+	function createPieceInstanceAsInfinite(id: string, fromPreviousPlayhead: boolean): PieceInstance {
+		return literal<PieceInstance>({
+			_id: protectString(id),
+			rundownId: protectString(''),
+			partInstanceId: protectString(''),
+			playlistActivationId: protectString('active'),
+			piece: literal<PieceInstancePiece>({
+				_id: protectString(`${id}_p`),
+				externalId: '',
+				startPartId: protectString(''),
+				enable: { start: 0 },
+				name: '',
+				lifespan: PieceLifespan.OutOnRundownChange,
+				sourceLayerId: '',
+				outputLayerId: '',
+				invalid: false,
+				content: {},
+				timelineObjectsString: protectString(''),
+				pieceType: IBlueprintPieceType.Normal,
+			}),
+			infinite: {
+				infiniteInstanceId: protectString(`${id}_inf`),
+				infiniteInstanceIndex: 0,
+				infinitePieceId: protectString(`${id}_p`),
+				fromPreviousPart: false,
+				fromPreviousPlayhead,
+			},
+		})
+	}
+
+	describe('replaceInfinitesFromPreviousPlayhead', () => {
+		it('works for an empty part', async () => {
+			const partInstance = createBasicDBPartInstance()
+			const model = new PlayoutPartInstanceModelImpl(partInstance, [], false)
+
+			expect(() => model.replaceInfinitesFromPreviousPlayhead([])).not.toThrow()
+			expect(model.pieceInstances).toEqual([])
+		})
+
+		it('keeps pieceInstance with fromPreviousPlayhead=false', async () => {
+			const partInstance = createBasicDBPartInstance()
+			const model = new PlayoutPartInstanceModelImpl(
+				partInstance,
+				[createPieceInstanceAsInfinite('p1', false)],
+				false
+			)
+
+			expect(() => model.replaceInfinitesFromPreviousPlayhead([])).not.toThrow()
+			expect(model.pieceInstances.map((p) => p.pieceInstance._id)).toEqual(['p1'])
+		})
+
+		it('deleted pieceInstance with fromPreviousPlayhead=true if no replacement provided', async () => {
+			const partInstance = createBasicDBPartInstance()
+			const model = new PlayoutPartInstanceModelImpl(
+				partInstance,
+				[createPieceInstanceAsInfinite('p1', true)],
+				false
+			)
+
+			expect(() => model.replaceInfinitesFromPreviousPlayhead([])).not.toThrow()
+			expect(model.pieceInstances.map((p) => p.pieceInstance._id)).toEqual([])
+		})
+
+		it('replaces pieceInstance with fromPreviousPlayhead=true if replacement provided', async () => {
+			const partInstance = createBasicDBPartInstance()
+			const model = new PlayoutPartInstanceModelImpl(
+				partInstance,
+				[createPieceInstanceAsInfinite('p1', true)],
+				false
+			)
+
+			expect(() =>
+				model.replaceInfinitesFromPreviousPlayhead([createPieceInstanceAsInfinite('p1', true)])
+			).not.toThrow()
+			expect(model.pieceInstances.map((p) => p.pieceInstance._id)).toEqual(['p1'])
+		})
+	})
+})


### PR DESCRIPTION
I believe the issue of some piece properties not being updated resulted from errors being thrown from `replaceInfinitesFromPreviousPlayhead` during onTake/onSetAsNext.
Following the suggestion from @Julusian, I modified the `replaceInfinitesFromPreviousPlayhead` so that pieces with `fromPreviousPlayhead: true` can be correctly replaced.
I added test coverage and performed some manual tests, no longer experiencing the unexpected behaviour.