### PR TITLE
Fix/core url not set for gui

### DIFF
--- a/meteor/client/main.html
+++ b/meteor/client/main.html
@@ -1,19 +1,19 @@
 <head>
 	<title>Sofie</title>
 	<meta charset="utf-8" />
-	<link rel="stylesheet" href="/origo-ui/dist/origo.css" />
+	<link rel="stylesheet" href="./origo-ui/dist/origo.css" />
 
 	<meta name="apple-mobile-web-app-title" content="Sofie" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
-	<link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
-	<link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-	<link rel="manifest" href="/site.webmanifest" data-href="/site.webmanifest" />
-	<link rel="mask-icon" href="/icons/safari-pinned-tab.svg" color="#5bbad5" />
-	<link rel="shortcut icon" href="/favicon.ico" />
+	<link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.png" />
+	<link rel="icon" type="image/png" sizes="32x32" href="./icons/favicon-32x32.png" />
+	<link rel="icon" type="image/png" sizes="16x16" href="./icons/favicon-16x16.png" />
+	<link rel="manifest" href="./site.webmanifest" data-href="./site.webmanifest" />
+	<link rel="mask-icon" href="./icons/safari-pinned-tab.svg" color="#5bbad5" />
+	<link rel="shortcut icon" href="./favicon.ico" />
 	<meta name="msapplication-TileColor" content="#da532c" />
-	<meta name="msapplication-config" content="/browserconfig.xml" />
+	<meta name="msapplication-config" content="./browserconfig.xml" />
 	<meta name="theme-color" content="#252627" />
 </head>
 <body>

--- a/meteor/client/main.tsx
+++ b/meteor/client/main.tsx
@@ -27,7 +27,7 @@ if ('serviceWorker' in navigator) {
 	window.addEventListener('load', () => {
 		// in some versions of Chrome, registering the Service Worker over HTTP throws an arror
 		if (window.location.protocol === 'https:' || window.location.hostname === 'localhost') {
-			navigator.serviceWorker.register('/sw.js').catch((err) => {
+			navigator.serviceWorker.register('./sw.js').catch((err) => {
 				logger.error('Error registering serviceWorker', err)
 			})
 		}

--- a/meteor/client/ui/App.tsx
+++ b/meteor/client/ui/App.tsx
@@ -58,6 +58,7 @@ import { DocumentTitleProvider } from '../lib/DocumentTitleProvider'
 import { Spinner } from '../lib/Spinner'
 import { catchError, isRunningInPWA } from '../lib/lib'
 import { firstIfArray, protectString } from '../../lib/lib'
+import { Meteor } from 'meteor/meteor'
 
 const NullComponent = () => null
 
@@ -89,6 +90,8 @@ export const App: React.FC = function App() {
 
 	const roles = useRoles(user, subsReady)
 	const featureFlags = useFeatureFlags()
+
+	const sofieRootPath = new URL(Meteor.absoluteUrl()).pathname
 
 	useEffect(() => {
 		if (user) return
@@ -201,7 +204,7 @@ export const App: React.FC = function App() {
 	return (
 		<UserContext.Provider value={user}>
 			<UserSubscriptionReadyContext.Provider value={subsReady}>
-				<Router getUserConfirmation={onNavigationUserConfirmation}>
+				<Router getUserConfirmation={onNavigationUserConfirmation} basename={sofieRootPath}>
 					<div className="container-fluid header-clear">
 						{/* Header switch - render the usual header for all pages but the rundown view */}
 						{isAuthenticated && (

--- a/meteor/client/ui/RundownList/GettingStarted.tsx
+++ b/meteor/client/ui/RundownList/GettingStarted.tsx
@@ -28,7 +28,7 @@ export function GettingStarted({ step }: Readonly<IGettingStartedProps>): JSX.El
 							visible={step === ToolTipStep.TOOLTIP_RUN_MIGRATIONS}
 							placement="bottom"
 						>
-							<a href="/settings/tools/migration">{t('Migrations')}</a>
+							<a href="./settings/tools/migration">{t('Migrations')}</a>
 						</Tooltip>
 					</li>
 				</ul>

--- a/meteor/client/ui/i18n.ts
+++ b/meteor/client/ui/i18n.ts
@@ -45,7 +45,7 @@ const i18nOptions = {
 	},
 
 	backend: {
-		loadPath: '/locales/{{lng}}/{{ns}}.json',
+		loadPath: './locales/{{lng}}/{{ns}}.json',
 	},
 
 	detection: {


### PR DESCRIPTION
## About the Contributor
This PR was made on behalf of BBC

## Type of Contribution
This is a bug fix


## Current Behavior
Currently the Sofie GUI had to have "/" as it's path to work.

## New Behavior
It's now possible to have a sub-path as root for the GUI


## Testing Instructions
Run a Nginx in front of Sofie Core with a reverse proxy AND wb socket support.
Like this:
```
 server {
        listen       8080;
        server_name  localhost;
    
        location /sofie {
            proxy_pass http://127.0.0.1:3000;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "upgrade";
        }
}
```

## Time Frame
This Fix is ready for testing


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x ] PR is ready to be reviewed.
- [ x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
