### PR TITLE
Fix: quickloop segment countdown timers

### DIFF
--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -342,6 +342,8 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	 */
 	setQuickLoopMarker(type: 'start' | 'end', marker: QuickLoopMarker | null): void
 
+	getSegmentsBetweenQuickLoopMarker(start: QuickLoopMarker, end: QuickLoopMarker): SegmentId[]
+
 	calculatePartTimings(
 		fromPartInstance: PlayoutPartInstanceModel | null,
 		toPartInstance: PlayoutPartInstanceModel,

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -792,6 +792,10 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 		this.#playlistHasChanged = true
 	}
 
+	getSegmentsBetweenQuickLoopMarker(start: QuickLoopMarker, end: QuickLoopMarker): SegmentId[] {
+		return this.quickLoopService.getSegmentsBetweenMarkers(start, end)
+	}
+
 	/** Lifecycle */
 
 	/** @deprecated */

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -593,7 +593,9 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 
 		if (regenerateActivationId) this.playlistImpl.activationId = getRandomId()
 
-		if (this.playlistImpl.quickLoop?.running) this.playlistImpl.quickLoop.running = false
+		// reset quickloop:
+		this.setQuickLoopMarker('start', null)
+		this.setQuickLoopMarker('end', null)
 
 		this.#playlistHasChanged = true
 	}

--- a/packages/job-worker/src/playout/quickLoopMarkers.ts
+++ b/packages/job-worker/src/playout/quickLoopMarkers.ts
@@ -5,6 +5,9 @@ import { runJobWithPlayoutModel } from './lock'
 import { updateTimeline } from './timeline/generate'
 import { selectNextPart } from './selectNextPart'
 import { setNextPart } from './setNext'
+import { resetPartInstancesWithPieceInstances } from './lib'
+import { QuickLoopMarker, QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 export async function handleSetQuickLoopMarker(context: JobContext, data: SetQuickLoopMarkerProps): Promise<void> {
 	return runJobWithPlayoutModel(
@@ -17,8 +20,73 @@ export async function handleSetQuickLoopMarker(context: JobContext, data: SetQui
 		async (playoutModel) => {
 			const playlist = playoutModel.playlist
 			if (!playlist.activationId) throw new Error(`Playlist has no activationId!`)
-			const wasQuickLoopRunning = playoutModel.playlist.quickLoop?.running
+			const oldProps = playoutModel.playlist.quickLoop
+			const wasQuickLoopRunning = oldProps?.running
 			playoutModel.setQuickLoopMarker(data.type, data.marker)
+
+			const markerChanged = (
+				markerA: QuickLoopMarker | undefined,
+				markerB: QuickLoopMarker | undefined
+			): boolean => {
+				if (!markerA || !markerB) return false
+
+				if (
+					(markerA.type === QuickLoopMarkerType.RUNDOWN ||
+						markerA.type === QuickLoopMarkerType.SEGMENT ||
+						markerA.type === QuickLoopMarkerType.PART) &&
+					(markerB.type === QuickLoopMarkerType.RUNDOWN ||
+						markerB.type === QuickLoopMarkerType.SEGMENT ||
+						markerB.type === QuickLoopMarkerType.PART)
+				) {
+					return markerA.id !== markerB.id
+				}
+
+				return false
+			}
+
+			if (playlist.currentPartInfo) {
+				// rundown is on air
+				let segmentsToReset: SegmentId[] = []
+
+				if (
+					playlist.quickLoop?.start &&
+					oldProps?.start &&
+					markerChanged(oldProps.start, playlist.quickLoop.start)
+				) {
+					// start marker changed
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						playlist.quickLoop.start,
+						oldProps.start
+					)
+				} else if (
+					playlist.quickLoop?.end &&
+					oldProps?.end &&
+					markerChanged(oldProps.end, playlist.quickLoop.end)
+				) {
+					// end marker changed
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						oldProps.end,
+						playlist.quickLoop.end
+					)
+				} else if (playlist.quickLoop?.start && playlist.quickLoop.end && !(oldProps?.start && oldProps.end)) {
+					// a new loop was created
+					segmentsToReset = playoutModel.getSegmentsBetweenQuickLoopMarker(
+						playlist.quickLoop.start,
+						playlist.quickLoop.end
+					)
+				}
+
+				// reset segments that have been added to the loop and are not on-air
+				resetPartInstancesWithPieceInstances(context, playoutModel, {
+					segmentId: {
+						$in: segmentsToReset.filter(
+							(segmentId) =>
+								segmentId !== playoutModel.currentPartInstance?.partInstance.segmentId &&
+								segmentId !== playoutModel.nextPartInstance?.partInstance.segmentId
+						),
+					},
+				})
+			}
 
 			if (wasQuickLoopRunning) {
 				const nextPart = selectNextPart(


### PR DESCRIPTION
2 parts to this:

1. When a segment was added to a currently playing loop it would not be reset until nexted, this makes it so that changing the marker will also reset any segments now included
2. The countdowns for parts in the loop were inconsistent and/or incorrect

Unit tests look to be broken in the base branch (bbc-r52)