### PR TITLE
fix: use segment budget duration for segment duration counter

### DIFF
--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -589,6 +589,7 @@ export class RundownTimingCalculator {
 
 		let remainingTimeOnCurrentPart: number | undefined = undefined
 		let currentPartWillAutoNext = false
+		let currentSegmentId: SegmentId | null | undefined
 		if (currentAIndex >= 0) {
 			const currentLivePartInstance = partInstances[currentAIndex]
 			const currentLivePart = currentLivePartInstance.part
@@ -614,10 +615,13 @@ export class RundownTimingCalculator {
 					: onAirPartDuration
 
 			currentPartWillAutoNext = !!(currentLivePart.autoNext && currentLivePart.expectedDuration)
+
+			currentSegmentId = currentLivePart.segmentId
 		}
 
 		return literal<RundownTimingContext>({
 			currentPartInstanceId: playlist ? playlist.currentPartInfo?.partInstanceId ?? null : undefined,
+			currentSegmentId: currentSegmentId,
 			totalPlaylistDuration: totalRundownDuration,
 			remainingPlaylistDuration: remainingRundownDuration,
 			asDisplayedPlaylistDuration: asDisplayedRundownDuration,
@@ -687,6 +691,8 @@ export class RundownTimingCalculator {
 export interface RundownTimingContext {
 	/** This stores the part instance that was active when this timing information was generated. */
 	currentPartInstanceId?: PartInstanceId | null
+	/** This stores the id of the segment that was active when this timing information was generated. */
+	currentSegmentId?: SegmentId | null
 	/** This is the total duration of the playlist as planned (using expectedDurations). */
 	totalPlaylistDuration?: number
 	/** This is the content remaining to be played in the playlist (based on the expectedDurations).  */

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartOrSegmentRemaining.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartOrSegmentRemaining.tsx
@@ -30,7 +30,7 @@ export const CurrentPartOrSegmentRemaining = withTiming<IPartRemainingProps, {}>
 	tickResolution: TimingTickResolution.Synced,
 	dataResolution: TimingDataResolution.Synced,
 })(
-	class CurrentPartRemaining extends React.Component<WithTiming<IPartRemainingProps>> {
+	class CurrentPartOrSegmentRemaining extends React.Component<WithTiming<IPartRemainingProps>> {
 		render(): JSX.Element | null {
 			if (!this.props.timingDurations || !this.props.timingDurations.currentTime) return null
 			if (this.props.timingDurations.currentPartInstanceId !== this.props.currentPartInstanceId) return null

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -6,6 +6,7 @@ import { PartUi } from '../../SegmentTimeline/SegmentTimelineContainer'
 import { calculatePartInstanceExpectedDurationWithTransition } from '@sofie-automation/corelib/dist/playout/timings'
 import { getPartInstanceTimingId } from '../../../lib/rundownTiming'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
+import { CountdownType } from '@sofie-automation/blueprints-integration'
 
 interface ISegmentDurationProps {
 	segment: DBSegment
@@ -28,30 +29,37 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 	props: WithTiming<ISegmentDurationProps>
 ) {
 	let duration: number | undefined = undefined
-	let budget = 0
 	let playedOut = 0
 
 	const segmentBudgetDuration = props.segment.segmentTiming?.budgetDuration
+	const segmentTimingType = props.segment.segmentTiming?.countdownType ?? CountdownType.PART_EXPECTED_DURATION
 
-	if (segmentBudgetDuration !== undefined) {
-		budget = segmentBudgetDuration
-	}
-	if (props.parts && props.timingDurations.partPlayed) {
-		const { partPlayed } = props.timingDurations
-		if (segmentBudgetDuration === undefined) {
+	let budget = segmentBudgetDuration ?? 0
+
+	if (segmentTimingType === CountdownType.SEGMENT_BUDGET_DURATION) {
+		if (props.timingDurations.currentSegmentId === props.segment._id) {
+			duration = props.timingDurations.remainingBudgetOnCurrentSegment ?? segmentBudgetDuration ?? 0
+		} else {
+			duration = segmentBudgetDuration ?? 0
+		}
+	} else {
+		if (props.parts && props.timingDurations.partPlayed) {
+			const { partPlayed } = props.timingDurations
+			if (segmentBudgetDuration === undefined) {
+				props.parts.forEach((part) => {
+					budget +=
+						part.instance.orphaned || part.instance.part.untimed
+							? 0
+							: calculatePartInstanceExpectedDurationWithTransition(part.instance) || 0
+				})
+			}
 			props.parts.forEach((part) => {
-				budget +=
-					part.instance.orphaned || part.instance.part.untimed
-						? 0
-						: calculatePartInstanceExpectedDurationWithTransition(part.instance) || 0
+				playedOut += (!part.instance.part.untimed ? partPlayed[getPartInstanceTimingId(part.instance)] : 0) || 0
 			})
 		}
-		props.parts.forEach((part) => {
-			playedOut += (!part.instance.part.untimed ? partPlayed[getPartInstanceTimingId(part.instance)] : 0) || 0
-		})
-	}
 
-	duration = budget - playedOut
+		duration = budget - playedOut
+	}
 
 	const showNegativeStyling = !props.fixed && !props.countUp
 

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -35,8 +35,11 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 	const segmentTimingType = props.segment.segmentTiming?.countdownType ?? CountdownType.PART_EXPECTED_DURATION
 
 	let budget = segmentBudgetDuration ?? 0
+	let hardFloor = false
 
 	if (segmentTimingType === CountdownType.SEGMENT_BUDGET_DURATION) {
+		hardFloor = true
+
 		if (props.timingDurations.currentSegmentId === props.segment._id) {
 			duration = props.timingDurations.remainingBudgetOnCurrentSegment ?? segmentBudgetDuration ?? 0
 		} else {
@@ -80,7 +83,7 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 					})}
 					role="timer"
 				>
-					{RundownUtils.formatDiffToTimecode(value, false, false, true, false, true, '+')}
+					{RundownUtils.formatDiffToTimecode(value, false, false, true, false, true, '+', false, hardFloor)}
 				</span>
 			</>
 		)


### PR DESCRIPTION
This makes the timer in the header of the segment match the time following the playhead, avoiding issues with the duration changing when adlibbing or playing out of order. Although it is now a second ahead of the playhead
![image](https://github.com/user-attachments/assets/bf091219-7f81-47c5-bc67-34e7e9a078e0)

~~They aren't in perfect sync though, as the header timer skips '0:00', resulting in it being a second ahead after crossing '0:00'.~~
Also when taking the segment, the timer jumps up by a second briefly, before counting down. This matches the behaviour of the timer on the playhead
