### PR TITLE
Feat: option to disable/enable buckets

### DIFF
--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -321,6 +321,7 @@ export function studioSettingsFrom(apiStudioSettings: APIStudioSettings): IStudi
 		enableQuickLoop: apiStudioSettings.enableQuickLoop,
 		forceQuickLoopAutoNext: forceQuickLoopAutoNextFrom(apiStudioSettings.forceQuickLoopAutoNext),
 		fallbackPartDuration: apiStudioSettings.fallbackPartDuration ?? DEFAULT_FALLBACK_PART_DURATION,
+		enableBuckets: apiStudioSettings.enableBuckets,
 	}
 }
 
@@ -340,6 +341,7 @@ export function APIStudioSettingsFrom(settings: IStudioSettings): APIStudioSetti
 		enableQuickLoop: settings.enableQuickLoop,
 		forceQuickLoopAutoNext: APIForceQuickLoopAutoNextFrom(settings.forceQuickLoopAutoNext),
 		fallbackPartDuration: settings.fallbackPartDuration,
+		enableBuckets: settings.enableBuckets,
 	}
 }
 

--- a/meteor/server/lib/rest/v1/studios.ts
+++ b/meteor/server/lib/rest/v1/studios.ts
@@ -186,4 +186,5 @@ export interface APIStudioSettings {
 	forceQuickLoopAutoNext?: 'disabled' | 'enabled_when_valid_duration' | 'enabled_forcing_min_duration'
 	minimumTakeSpan?: number
 	fallbackPartDuration?: number
+	enableBuckets?: boolean
 }

--- a/meteor/server/migration/X_X_X.ts
+++ b/meteor/server/migration/X_X_X.ts
@@ -187,4 +187,33 @@ export const addSteps = addMigrationSteps(CURRENT_SYSTEM_VERSION, [
 			}
 		},
 	},
+	{
+		id: `add an EnableBuckets option in Studio->Settings`,
+		canBeRunAutomatically: true,
+		validate: async () => {
+			const studios = await Studios.findFetchAsync({
+				$or: [{ 'settings.enableBuckets': { $exists: false } }],
+			})
+
+			if (studios.length > 0) {
+				return 'studios needs to have settings.enableBuckets defined'
+			}
+
+			return false
+		},
+		migrate: async () => {
+			const studios = await Studios.findFetchAsync({
+				$or: [{ 'settings.enableBuckets': { $exists: false } }],
+			})
+
+			for (const studio of studios) {
+				// In earlier versions buckets was enabled by default:
+				await Studios.updateAsync(studio._id, {
+					$set: {
+						'settings.enableBuckets': true,
+					},
+				})
+			}
+		},
+	},
 ])

--- a/packages/corelib/src/dataModel/Studio.ts
+++ b/packages/corelib/src/dataModel/Studio.ts
@@ -88,6 +88,11 @@ export interface IStudioSettings {
 	 * Default: 3000
 	 */
 	fallbackPartDuration?: number
+
+	/**
+	 * Enable buckets - the default behavior is to have buckets.
+	 */
+	enableBuckets?: boolean
 }
 
 export type StudioLight = Omit<DBStudio, 'mappingsWithOverrides' | 'blueprintConfigWithOverrides'>

--- a/packages/webui/src/client/ui/RundownView.tsx
+++ b/packages/webui/src/client/ui/RundownView.tsx
@@ -1475,7 +1475,8 @@ const RundownViewContent = translateWithTracker<IPropsWithReady, IState, ITracke
 		rundownHeaderLayoutId: protectString((params['rundownHeaderLayout'] as string) || ''),
 		miniShelfLayoutId: protectString((params['miniShelfLayout'] as string) || ''),
 		shelfDisplayOptions: {
-			enableBuckets: displayOptions.includes('buckets'),
+			// If buckets are enabled in Studiosettings, it can also be filtered in the URLs display options.
+			enableBuckets: studio?.settings.enableBuckets && displayOptions.includes('buckets'),
 			enableLayout: displayOptions.includes('layout') || displayOptions.includes('shelfLayout'),
 			enableInspector: displayOptions.includes('inspector'),
 		},

--- a/packages/webui/src/client/ui/Settings/Studio/Generic.tsx
+++ b/packages/webui/src/client/ui/Settings/Studio/Generic.tsx
@@ -249,6 +249,17 @@ export const StudioGenericProperties = withTranslation()(
 					</label>
 
 					<label className="field">
+						<LabelActual label={t('Enable Buckets')} />
+						<EditAttribute
+							modifiedClassName="bghl"
+							attribute="settings.enableBuckets"
+							obj={this.props.studio}
+							type="checkbox"
+							collection={Studios}
+						/>
+					</label>
+
+					<label className="field">
 						<LabelActual label={t('Enable QuickLoop')} />
 						<EditAttribute
 							modifiedClassName="bghl"


### PR DESCRIPTION
This adds an Enable Buckets option in settings, so it's possible to completely disable Buckets.
A migration has been added where this setting is default true to support previous core versions.