### PR TITLE
chore: Changed styling of the liveSpeak and remoteSpeak sourceLayers

### DIFF
--- a/packages/webui/src/client/styles/_itemTypeColors.scss
+++ b/packages/webui/src/client/styles/_itemTypeColors.scss
@@ -10,34 +10,39 @@ $segment-layer-background-graphics: #dc5c00;
 $segment-layer-background-graphics--second: darken($segment-layer-background-graphics, 10%);
 $segment-layer-border-live-speak: #2f74ff;
 /** Gradients need to be defined with each color separately, so that they can be applied in SVG **/
+$segment-layer-background-gradient-divider: rgba(0, 0, 0, 0.5) 1px;
 $segment-layer-background-live-speak-1: #2f74ff;
 $segment-layer-background-live-speak-2: #39762b;
 $segment-layer-background-live-speak: linear-gradient(
 	to bottom,
-	$segment-layer-background-live-speak-1 50%,
-	$segment-layer-background-live-speak-2 50%
+	$segment-layer-background-live-speak-1 70%,
+	$segment-layer-background-gradient-divider,
+	$segment-layer-background-live-speak-2 72%
 );
 $segment-layer-background-live-speak--second-1: darken(#2f74ff, 10%);
 $segment-layer-background-live-speak--second-2: darken(#39762b, 10%);
 $segment-layer-background-live-speak--second: linear-gradient(
 	to bottom,
-	$segment-layer-background-live-speak--second-1 50%,
-	$segment-layer-background-live-speak--second-2 50%
+	$segment-layer-background-live-speak--second-1 70%,
+	$segment-layer-background-gradient-divider,
+	$segment-layer-background-live-speak--second-2 72%
 );
 $segment-layer-border-remote-speak: #e80064;
 $segment-layer-background-remote-speak-1: #e80064;
 $segment-layer-background-remote-speak-2: #39762b;
 $segment-layer-background-remote-speak: linear-gradient(
 	to bottom,
-	$segment-layer-background-remote-speak-1 50%,
-	$segment-layer-background-remote-speak-2 50%
+	$segment-layer-background-remote-speak-1 70%,
+	$segment-layer-background-gradient-divider,
+	$segment-layer-background-remote-speak-2 72%
 );
 $segment-layer-background-remote-speak--second-1: darken(#e80064, 10%);
 $segment-layer-background-remote-speak--second-2: darken(#39762b, 10%);
 $segment-layer-background-remote-speak--second: linear-gradient(
 	to bottom,
-	$segment-layer-background-remote-speak--second-1 50%,
-	$segment-layer-background-remote-speak--second-2 50%
+	$segment-layer-background-remote-speak--second-1 70%,
+	$segment-layer-background-gradient-divider,
+	$segment-layer-background-remote-speak--second-2 72%
 );
 $segment-layer-background-remote: #e80064;
 $segment-layer-background-remote--second: darken($segment-layer-background-remote, 10%);


### PR DESCRIPTION
Changed styling of the liveSpeak and remoteSpeak sourceLayer types so that main upper section of the pieces are made 20% taller, and lower green section of the pieces (representing audio) is made 20% smaller. Also added a 1 pixel high semi-transparent separator to aid color-deficient users in seeing the contrast, especially for the liveSpeak pieces with blue/green tones.

The justification for this change is to visually separate these pieces from split pieces.

## About the Contributor

This pull request is posted on behalf of the BBC.


## Type of Contribution

This is a:

Other (styling improvment)


## Current Behavior
 The styling used to be a 50/50 split, making them look just like splits. 


## New Behavior
70/30 piece styling with the main source becoming more prominent.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

GUI only.


## Time Frame
 
* Not urgent, but we would like to get this merged into the in-development release.



## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation 
