### PR TITLE
feat: UI piece retiming (BBC release53)

### DIFF
--- a/meteor/server/publications/partInstancesUI/reactiveContentCache.ts
+++ b/meteor/server/publications/partInstancesUI/reactiveContentCache.ts
@@ -5,7 +5,6 @@ import { MongoFieldSpecifierOnesStrict, MongoFieldSpecifierZeroes } from '@sofie
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { DBStudio, IStudioSettings } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
-import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 

--- a/packages/blueprints-integration/src/ingest.ts
+++ b/packages/blueprints-integration/src/ingest.ts
@@ -130,6 +130,7 @@ export enum DefaultUserOperationsTypes {
 	REVERT_RUNDOWN = '__sofie-revert-rundown',
 	UPDATE_PROPS = '__sofie-update-props',
 	IMPORT_MOS_ITEM = '__sofie-import-mos',
+	RETIME_PIECE = '__sofie-retime-piece',
 }
 
 export interface DefaultUserOperationRevertRundown {
@@ -159,6 +160,17 @@ export type DefaultUserOperationImportMOSItem = {
 
 	payloadType: string
 	payload: any
+}
+
+export type DefaultUserOperationRetimePiece = {
+	id: DefaultUserOperationsTypes.RETIME_PIECE
+	payload: {
+		segmentExternalId: string
+		partExternalId: string
+
+		inPoint: number
+		// note - at some point this could also include an updated duration
+	}
 }
 
 export type DefaultUserOperations =

--- a/packages/blueprints-integration/src/ingest.ts
+++ b/packages/blueprints-integration/src/ingest.ts
@@ -179,6 +179,7 @@ export type DefaultUserOperations =
 	| DefaultUserOperationRevertPart
 	| DefaultUserOperationEditProperties
 	| DefaultUserOperationImportMOSItem
+	| DefaultUserOperationRetimePiece
 
 export interface UserOperationChange<TCustomBlueprintOperations extends { id: string } = never> {
 	/** Indicate that this change is from user operations */

--- a/packages/blueprints-integration/src/triggers.ts
+++ b/packages/blueprints-integration/src/triggers.ts
@@ -272,6 +272,12 @@ export interface IShelfAction extends ITriggeredActionBase {
 	filterChain: IGUIContextFilterLink[]
 }
 
+export interface IEditModeAction extends ITriggeredActionBase {
+	action: ClientActions.editMode
+	state: true | false | 'toggle'
+	filterChain: IGUIContextFilterLink[]
+}
+
 export interface IGoToOnAirLineAction extends ITriggeredActionBase {
 	action: ClientActions.goToOnAirLine
 	filterChain: IGUIContextFilterLink[]
@@ -325,6 +331,7 @@ export type SomeAction =
 	| IRundownPlaylistResetAction
 	| IRundownPlaylistResyncAction
 	| IShelfAction
+	| IEditModeAction
 	| IGoToOnAirLineAction
 	| IRewindSegmentsAction
 	| IShowEntireCurrentSegmentAction

--- a/packages/corelib/src/dataModel/UserEditingDefinitions.ts
+++ b/packages/corelib/src/dataModel/UserEditingDefinitions.ts
@@ -47,6 +47,12 @@ export interface CoreUserEditingDefinitionForm {
 	translationNamespaces: string[]
 }
 
+export interface CoreUserEditingDefinitionSofie {
+	type: UserEditingType.SOFIE
+	/** Id of this operation */
+	id: DefaultUserOperationsTypes
+}
+
 export interface CoreUserEditingProperties {
 	/**
 	 * These properties are dependent on the (primary) piece type, the user will get the option

--- a/packages/job-worker/src/blueprints/context/lib.ts
+++ b/packages/job-worker/src/blueprints/context/lib.ts
@@ -551,27 +551,27 @@ function translateUserEditsToBlueprint(
 		userEdits.map((userEdit) => {
 			switch (userEdit.type) {
 				case UserEditingType.ACTION:
-					return {
+					return literal<UserEditingDefinitionAction>({
 						type: UserEditingType.ACTION,
 						id: userEdit.id,
 						label: omit(userEdit.label, 'namespaces'),
 						icon: userEdit.icon,
 						iconInactive: userEdit.iconInactive,
 						isActive: userEdit.isActive,
-					} satisfies Complete<UserEditingDefinitionAction>
+					})
 				case UserEditingType.FORM:
-					return {
+					return literal<UserEditingDefinitionForm>({
 						type: UserEditingType.FORM,
 						id: userEdit.id,
 						label: omit(userEdit.label, 'namespaces'),
 						schema: clone(userEdit.schema),
 						currentValues: clone(userEdit.currentValues),
-					} satisfies Complete<UserEditingDefinitionForm>
+					})
 				case UserEditingType.SOFIE:
-					return {
+					return literal<UserEditingDefinitionSofieDefault>({
 						type: UserEditingType.SOFIE,
 						id: userEdit.id,
-					} satisfies Complete<UserEditingDefinitionSofieDefault>
+					})
 				default:
 					assertNever(userEdit)
 					return undefined
@@ -613,28 +613,28 @@ export function translateUserEditsFromBlueprint(
 		userEdits.map((userEdit) => {
 			switch (userEdit.type) {
 				case UserEditingType.ACTION:
-					return {
+					return literal<CoreUserEditingDefinitionAction>({
 						type: UserEditingType.ACTION,
 						id: userEdit.id,
 						label: wrapTranslatableMessageFromBlueprints(userEdit.label, blueprintIds),
 						icon: userEdit.icon,
 						iconInactive: userEdit.iconInactive,
 						isActive: userEdit.isActive,
-					} satisfies Complete<CoreUserEditingDefinitionAction>
+					})
 				case UserEditingType.FORM:
-					return {
+					return literal<CoreUserEditingDefinitionForm>({
 						type: UserEditingType.FORM,
 						id: userEdit.id,
 						label: wrapTranslatableMessageFromBlueprints(userEdit.label, blueprintIds),
 						schema: clone(userEdit.schema),
 						currentValues: clone(userEdit.currentValues),
 						translationNamespaces: unprotectStringArray(blueprintIds),
-					} satisfies Complete<CoreUserEditingDefinitionForm>
+					})
 				case UserEditingType.SOFIE:
-					return {
+					return literal<CoreUserEditingDefinitionSofie>({
 						type: UserEditingType.SOFIE,
 						id: userEdit.id,
-					} satisfies Complete<CoreUserEditingDefinitionSofie>
+					})
 				default:
 					assertNever(userEdit)
 					return undefined

--- a/packages/meteor-lib/src/triggers/RundownViewEventBus.ts
+++ b/packages/meteor-lib/src/triggers/RundownViewEventBus.ts
@@ -29,6 +29,7 @@ export enum RundownViewEvents {
 	REVEAL_IN_SHELF = 'revealInShelf',
 	SWITCH_SHELF_TAB = 'switchShelfTab',
 	SHELF_STATE = 'shelfState',
+	EDIT_MODE = 'editMode',
 	MINI_SHELF_QUEUE_ADLIB = 'miniShelfQueueAdLib',
 	GO_TO_PART = 'goToPart',
 	GO_TO_PART_INSTANCE = 'goToPartInstance',
@@ -71,6 +72,10 @@ export interface SwitchToShelfTabEvent extends IEventContext {
 }
 
 export interface ShelfStateEvent extends IEventContext {
+	state: boolean | 'toggle'
+}
+
+export interface EditModeEvent extends IEventContext {
 	state: boolean | 'toggle'
 }
 
@@ -139,6 +144,7 @@ export interface RundownViewEventBusEvents {
 	[RundownViewEvents.SEGMENT_ZOOM_ON]: []
 	[RundownViewEvents.SEGMENT_ZOOM_OFF]: []
 	[RundownViewEvents.SHELF_STATE]: [e: ShelfStateEvent]
+	[RundownViewEvents.EDIT_MODE]: [e: EditModeEvent]
 	[RundownViewEvents.REVEAL_IN_SHELF]: [e: RevealInShelfEvent]
 	[RundownViewEvents.SWITCH_SHELF_TAB]: [e: SwitchToShelfTabEvent]
 	[RundownViewEvents.MINI_SHELF_QUEUE_ADLIB]: [e: MiniShelfQueueAdLibEvent]

--- a/packages/meteor-lib/src/triggers/actionFactory.ts
+++ b/packages/meteor-lib/src/triggers/actionFactory.ts
@@ -286,6 +286,17 @@ function createShelfAction(_filterChain: IGUIContextFilterLink[], state: boolean
 	}
 }
 
+function createEditModeAction(_filterChain: IGUIContextFilterLink[], state: boolean | 'toggle'): ExecutableAction {
+	return {
+		action: ClientActions.editMode,
+		execute: () => {
+			RundownViewEventBus.emit(RundownViewEvents.EDIT_MODE, {
+				state,
+			})
+		},
+	}
+}
+
 function createMiniShelfQueueAdLibAction(_filterChain: IGUIContextFilterLink[], forward: boolean): ExecutableAction {
 	return {
 		action: ClientActions.miniShelfQueueAdLib,
@@ -442,6 +453,8 @@ export function createAction(
 	switch (action.action) {
 		case ClientActions.shelf:
 			return createShelfAction(action.filterChain, action.state)
+		case ClientActions.editMode:
+			return createEditModeAction(action.filterChain, action.state)
 		case ClientActions.goToOnAirLine:
 			return createGoToOnAirLineAction(action.filterChain)
 		case ClientActions.rewindSegments:

--- a/packages/shared-lib/src/core/model/ShowStyle.ts
+++ b/packages/shared-lib/src/core/model/ShowStyle.ts
@@ -107,6 +107,7 @@ export enum ClientActions {
 	'rewindSegments' = 'rewindSegments',
 	'showEntireCurrentSegment' = 'showEntireCurrentSegment',
 	'miniShelfQueueAdLib' = 'miniShelfQueueAdLib',
+	'editMode' = 'editMode',
 }
 
 export enum DeviceActions {

--- a/packages/webui/src/client/lib/ui/pieceUiClassNames.ts
+++ b/packages/webui/src/client/lib/ui/pieceUiClassNames.ts
@@ -19,7 +19,8 @@ export function pieceUiClassNames(
 	uiState?: {
 		leftAnchoredWidth: number
 		rightAnchoredWidth: number
-	}
+	},
+	draggable?: boolean
 ): string {
 	const typeClass = layerType ? RundownUtils.getSourceLayerClassName(layerType) : ''
 
@@ -59,5 +60,7 @@ export function pieceUiClassNames(
 		'invert-flash': highlight,
 
 		'element-selected': selected,
+
+		'draggable-element': draggable,
 	})
 }

--- a/packages/webui/src/client/styles/elementSelected.scss
+++ b/packages/webui/src/client/styles/elementSelected.scss
@@ -18,3 +18,7 @@ $glow-color: rgba(255, 255, 255, 0.58);
 		}
 	}
 }
+
+.draggable-element {
+	border: dotted white 1px;
+}

--- a/packages/webui/src/client/ui/RundownView/DragContext.ts
+++ b/packages/webui/src/client/ui/RundownView/DragContext.ts
@@ -1,0 +1,39 @@
+import { PartInstanceId, PieceInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { createContext } from 'react'
+import { PieceUi } from '../SegmentContainer/withResolvedSegment'
+
+export interface IDragContext {
+	/**
+	 * Indicate a drag operation on a piece has started
+	 * @param piece The piece that is being dragged
+	 * @param timeScale The current TimeScale of the segment
+	 * @param position The position of the mouse
+	 * @param elementOffset The x-coordinate of the element relative to the mouse position
+	 * @param limitToSegment Whether the piece can be dragged to other segments (note: if the other segment does not have the right source layer the piece will look to have disappeared... consider omitting this is a todo)
+	 */
+	startDrag: (
+		piece: PieceUi,
+		timeScale: number,
+		position: { x: number; y: number },
+		elementOffset?: number,
+		limitToSegment?: SegmentId
+	) => void
+	/**
+	 * Indicate the part the mouse is on has changed
+	 * @param partId The part id that the mouse is currently hovering on
+	 * @param segmentId The segment the part currenly hover is in
+	 * @param position The position of the part in absolute coords to the screen
+	 */
+	setHoveredPart: (partId: PartInstanceId, segmentId: SegmentId, position: { x: number; y: number }) => void
+
+	/**
+	 * PieceId of the piece that is being dragged
+	 */
+	pieceId: undefined | PieceInstanceId
+	/**
+	 * The piece with any local overrides coming from dragging it around (i.e. changed renderedInPoint)
+	 */
+	piece: undefined | PieceUi
+}
+
+export const dragContext = createContext<IDragContext | undefined>(undefined) // slay.

--- a/packages/webui/src/client/ui/RundownView/DragContext.ts
+++ b/packages/webui/src/client/ui/RundownView/DragContext.ts
@@ -27,6 +27,11 @@ export interface IDragContext {
 	setHoveredPart: (partId: PartInstanceId, segmentId: SegmentId, position: { x: number; y: number }) => void
 
 	/**
+	 * Whether dragging is enabled
+	 */
+	enabled: boolean
+
+	/**
 	 * PieceId of the piece that is being dragged
 	 */
 	pieceId: undefined | PieceInstanceId

--- a/packages/webui/src/client/ui/RundownView/DragContextProvider.tsx
+++ b/packages/webui/src/client/ui/RundownView/DragContextProvider.tsx
@@ -1,0 +1,149 @@
+import { PartInstanceId, PieceInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PropsWithChildren, useRef, useState } from 'react'
+import { dragContext, IDragContext } from './DragContext'
+import { PieceUi } from '../SegmentContainer/withResolvedSegment'
+import { doUserAction, UserAction } from '../../lib/clientUserAction'
+import { MeteorCall } from '../../lib/meteorApi'
+import { TFunction } from 'i18next'
+import { UIParts } from '../Collections.js'
+import { Segments } from '../../collections/index.js'
+import { literal } from '../../lib/tempLib.js'
+import { DefaultUserOperationRetimePiece, DefaultUserOperationsTypes } from '@sofie-automation/blueprints-integration'
+
+const DRAG_TIMEOUT = 10000
+
+interface Props {
+	t: TFunction
+}
+
+// notes: this doesn't limit dragging between rundowns right now but I'm not sure if the ingest stage will be happy with that - mint
+export function DragContextProvider({ t, children }: PropsWithChildren<Props>): JSX.Element {
+	const [pieceId, setPieceId] = useState<undefined | PieceInstanceId>(undefined)
+	const [piece, setPiece] = useState<undefined | PieceUi>(undefined)
+
+	const partIdRef = useRef<undefined | PartInstanceId>(undefined)
+	const positionRef = useRef({ x: 0, y: 0 })
+	const segmentIdRef = useRef<undefined | SegmentId>(undefined)
+
+	const startDrag = (
+		ogPiece: PieceUi,
+		timeScale: number,
+		pos: { x: number; y: number },
+		elementOffset?: number,
+		limitToSegment?: SegmentId
+	) => {
+		if (pieceId) return // a drag is currently in progress....
+
+		const inPoint = ogPiece.renderedInPoint ?? 0
+		segmentIdRef.current = limitToSegment
+		positionRef.current = pos
+		setPieceId(ogPiece.instance._id)
+
+		let localPiece = ogPiece // keep a copy of the overriden piece because react does not let us access the state of the context easily
+
+		const onMove = (e: MouseEvent) => {
+			const newInPoint =
+				(!partIdRef.current ? inPoint : (elementOffset ?? 0) / timeScale) +
+				(e.clientX - positionRef.current.x) / timeScale
+
+			localPiece = {
+				...ogPiece,
+				instance: { ...ogPiece.instance, partInstanceId: partIdRef.current ?? ogPiece.instance.partInstanceId },
+				renderedInPoint: newInPoint,
+			}
+			setPiece(localPiece)
+		}
+
+		const cleanup = () => {
+			// unset state - note: for ux reasons this runs after the backend operation has returned a result
+			setPieceId(undefined)
+			setPiece(undefined)
+			partIdRef.current = undefined
+			segmentIdRef.current = undefined
+		}
+
+		const onMouseUp = (e: MouseEvent) => {
+			// detach from the mouse
+			document.removeEventListener('mousemove', onMove)
+			document.removeEventListener('mouseup', onMouseUp)
+
+			// process the drag
+			if (!localPiece || localPiece.renderedInPoint === ogPiece.renderedInPoint) return cleanup()
+
+			// find the parts so we can get their externalId
+			const startPartId = localPiece.instance.piece.startPartId // this could become a funny thing with infinites
+			const part = startPartId ? UIParts.findOne(startPartId) : undefined
+			const oldPart =
+				startPartId === ogPiece.instance.piece.startPartId
+					? part
+					: ogPiece.instance.piece.startPartId
+						? UIParts.findOne(ogPiece.instance.piece.startPartId)
+						: undefined
+			if (!part) return cleanup() // tough to continue without a parent for the piece
+
+			// find the Segment's External ID
+			const segment = Segments.findOne(part?.segmentId)
+			const oldSegment = part?.segmentId === oldPart?.segmentId ? segment : Segments.findOne(oldPart?.segmentId)
+			if (!segment) return
+
+			const operationTarget = {
+				segmentExternalId: oldSegment?.externalId,
+				partExternalId: oldPart?.externalId,
+				pieceExternalId: ogPiece.instance.piece.externalId,
+			}
+			doUserAction(
+				t,
+				e,
+				UserAction.EXECUTE_USER_OPERATION,
+				(e, ts) =>
+					MeteorCall.userAction.executeUserChangeOperation(
+						e,
+						ts,
+						part.rundownId,
+						operationTarget,
+						literal<DefaultUserOperationRetimePiece>({
+							id: DefaultUserOperationsTypes.RETIME_PIECE,
+							payload: {
+								segmentExternalId: segment.externalId,
+								partExternalId: part.externalId,
+
+								inPoint: localPiece.renderedInPoint ?? inPoint,
+							},
+						})
+					),
+				() => {
+					cleanup()
+				}
+			)
+		}
+
+		document.addEventListener('mousemove', onMove)
+		document.addEventListener('mouseup', onMouseUp)
+
+		setTimeout(() => {
+			// after the timeout we want to bail out in case something went wrong
+			document.removeEventListener('mousemove', onMove)
+			document.removeEventListener('mouseup', onMouseUp)
+
+			cleanup()
+		}, DRAG_TIMEOUT)
+	}
+	const setHoveredPart = (updatedPartId: PartInstanceId, segmentId: SegmentId, pos: { x: number; y: number }) => {
+		if (!pieceId) return
+		if (updatedPartId === piece?.instance.partInstanceId) return
+		if (segmentIdRef.current && segmentIdRef.current !== segmentId) return
+
+		partIdRef.current = updatedPartId
+		positionRef.current = pos
+	}
+
+	const ctx = literal<IDragContext>({
+		pieceId,
+		piece,
+
+		startDrag,
+		setHoveredPart,
+	})
+
+	return <dragContext.Provider value={ctx}>{children}</dragContext.Provider>
+}

--- a/packages/webui/src/client/ui/RundownView/DragContextProvider.tsx
+++ b/packages/webui/src/client/ui/RundownView/DragContextProvider.tsx
@@ -1,14 +1,18 @@
 import { PartInstanceId, PieceInstanceId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { PropsWithChildren, useRef, useState } from 'react'
-import { dragContext, IDragContext } from './DragContext'
-import { PieceUi } from '../SegmentContainer/withResolvedSegment'
-import { doUserAction, UserAction } from '../../lib/clientUserAction'
-import { MeteorCall } from '../../lib/meteorApi'
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react'
+import { dragContext, IDragContext } from './DragContext.js'
+import { PieceUi } from '../SegmentContainer/withResolvedSegment.js'
+import { doUserAction, UserAction } from '../../lib/clientUserAction.js'
+import { MeteorCall } from '../../lib/meteorApi.js'
 import { TFunction } from 'i18next'
 import { UIParts } from '../Collections.js'
 import { Segments } from '../../collections/index.js'
 import { literal } from '../../lib/tempLib.js'
 import { DefaultUserOperationRetimePiece, DefaultUserOperationsTypes } from '@sofie-automation/blueprints-integration'
+import RundownViewEventBus, {
+	RundownViewEvents,
+	EditModeEvent,
+} from '@sofie-automation/meteor-lib/dist/triggers/RundownViewEventBus'
 
 const DRAG_TIMEOUT = 10000
 
@@ -20,6 +24,8 @@ interface Props {
 export function DragContextProvider({ t, children }: PropsWithChildren<Props>): JSX.Element {
 	const [pieceId, setPieceId] = useState<undefined | PieceInstanceId>(undefined)
 	const [piece, setPiece] = useState<undefined | PieceUi>(undefined)
+
+	const [enabled, setEnabled] = useState(false)
 
 	const partIdRef = useRef<undefined | PartInstanceId>(undefined)
 	const positionRef = useRef({ x: 0, y: 0 })
@@ -137,9 +143,26 @@ export function DragContextProvider({ t, children }: PropsWithChildren<Props>): 
 		positionRef.current = pos
 	}
 
+	const onSetEditMode = useCallback((e: EditModeEvent) => {
+		if (e.state === 'toggle') {
+			setEnabled((s) => !s)
+		} else {
+			setEnabled(e.state)
+		}
+	}, [])
+
+	useEffect(() => {
+		RundownViewEventBus.on(RundownViewEvents.EDIT_MODE, onSetEditMode)
+		return () => {
+			RundownViewEventBus.off(RundownViewEvents.EDIT_MODE, onSetEditMode)
+		}
+	})
+
 	const ctx = literal<IDragContext>({
 		pieceId,
 		piece,
+
+		enabled,
 
 		startDrag,
 		setHoveredPart,

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/SourceLayer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { MouseEventHandler, useCallback, useContext, useState } from 'react'
 import _ from 'underscore'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { literal, protectString, unprotectString } from '../../../lib/tempLib.js'
@@ -11,6 +11,7 @@ import { SourceLayerItemContainer } from '../SourceLayerItemContainer.js'
 import { contextMenuHoldToDisplayTime } from '../../../lib/lib.js'
 import { UIStudio } from '@sofie-automation/meteor-lib/dist/api/studios'
 import { PieceInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { dragContext } from '../../RundownView/DragContext.js'
 
 export interface ISourceLayerPropsBase {
 	key: string
@@ -90,6 +91,19 @@ export function useMouseContext(props: ISourceLayerPropsBase): {
 
 export function SourceLayer(props: Readonly<ISourceLayerProps>): JSX.Element {
 	const { getPartContext, onMouseDown } = useMouseContext(props)
+	const dragCtx = useContext(dragContext)
+
+	const pieces =
+		dragCtx?.piece && dragCtx.piece.sourceLayer?._id === props.layer._id
+			? (props.layer.pieces ?? []).filter((p) => p.instance._id !== dragCtx.piece?.instance._id).concat(dragCtx.piece)
+			: props.layer.pieces
+
+	const onMouseEnter: MouseEventHandler<HTMLElement> = (e) => {
+		if (!dragCtx) return
+
+		const pos = (e.target as HTMLDivElement).getBoundingClientRect() // ugly cast here because the event handler doesn't cast for us
+		dragCtx.setHoveredPart(props.part.instance._id, props.segment._id, { x: pos.x, y: pos.y })
+	}
 
 	return (
 		<ContextMenuTrigger
@@ -99,6 +113,7 @@ export function SourceLayer(props: Readonly<ISourceLayerProps>): JSX.Element {
 				//@ts-expect-error A Data attribue is perfectly fine
 				'data-layer-id': props.layer._id,
 				onMouseDownCapture: (e) => onMouseDown(e),
+				onMouseEnter,
 				role: 'log',
 				'aria-live': 'assertive',
 				'aria-label': props.layer.name,
@@ -106,9 +121,9 @@ export function SourceLayer(props: Readonly<ISourceLayerProps>): JSX.Element {
 			holdToDisplay={contextMenuHoldToDisplayTime()}
 			collect={getPartContext}
 		>
-			{props.layer.pieces !== undefined
+			{pieces !== undefined
 				? _.chain(
-						props.layer.pieces.filter((piece) => {
+						pieces.filter((piece) => {
 							// filter only pieces belonging to this part
 							return piece.instance.partInstanceId === props.part.instance._id
 								? // filter only pieces, that have not been hidden from the UI

--- a/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -164,6 +164,9 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 	)
 	const itemDblClick = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
+			e.preventDefault()
+			e.stopPropagation()
+
 			if (studio?.settings.enableUserEdits && !studio?.settings.allowPieceDirectPlay) {
 				const pieceId = piece.instance.piece._id
 				if (!selectElementContext.isSelected(pieceId)) {
@@ -171,13 +174,6 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 				} else {
 					selectElementContext.clearSelections()
 				}
-				// Until a proper data structure, the only reference is a part.
-				// const partId = this.props.part.instance.part._id
-				// if (!selectElementContext.isSelected(partId)) {
-				// 	selectElementContext.clearAndSetSelection({ type: 'part', elementId: partId })
-				// } else {
-				// 	selectElementContext.clearSelections()
-				// }
 			} else if (typeof onDoubleClick === 'function') {
 				onDoubleClick(piece, e)
 			}
@@ -531,29 +527,31 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 			...props,
 			...state,
 		}
+		// Key cannot be part of a spread operator, therefore needs to be kept out of elProps
+		const elKey = unprotectString(piece.instance._id)
 
 		switch (layer.type) {
 			case SourceLayerType.SCRIPT:
 				// case SourceLayerType.MIC:
-				return <MicSourceRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <MicSourceRenderer key={elKey} {...elProps} />
 			case SourceLayerType.VT:
 			case SourceLayerType.LIVE_SPEAK:
-				return <VTSourceRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <VTSourceRenderer key={elKey} {...elProps} />
 			case SourceLayerType.GRAPHICS:
 			case SourceLayerType.LOWER_THIRD:
 			case SourceLayerType.STUDIO_SCREEN:
-				return <L3rdSourceRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <L3rdSourceRenderer key={elKey} {...elProps} />
 			case SourceLayerType.SPLITS:
-				return <SplitsSourceRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <SplitsSourceRenderer key={elKey} {...elProps} />
 
 			case SourceLayerType.TRANSITION:
 				// TODOSYNC: TV2 uses other renderers, to be discussed.
 
-				return <TransitionSourceRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <TransitionSourceRenderer key={elKey} {...elProps} />
 			case SourceLayerType.LOCAL:
-				return <LocalLayerItemRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <LocalLayerItemRenderer key={elKey} {...elProps} />
 			default:
-				return <DefaultLayerItemRenderer key={unprotectString(piece.instance._id)} {...elProps} />
+				return <DefaultLayerItemRenderer key={elKey} {...elProps} />
 		}
 	}
 

--- a/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -122,6 +122,9 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 	const [rightAnchoredWidth, setRightAnchoredWidth] = useState<number>(0)
 
 	const dragCtx = useContext(dragContext)
+	const hasDraggableElement = !!piece.instance.piece.userEditOperations?.find(
+		(op) => op.type === UserEditingType.SOFIE && op.id === DefaultUserOperationsTypes.RETIME_PIECE
+	)
 
 	const state = {
 		highlight,
@@ -193,25 +196,11 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			e.preventDefault()
 			e.stopPropagation()
-			console.log(
-				'mousedown',
-				UserEditingType.SOFIE,
-				DefaultUserOperationsTypes,
-				piece.instance.piece.userEditOperations?.map(
-					(op) => op.type === UserEditingType.SOFIE && op.id === '__sofie-retime-piece'
-				)
-			)
 
-			if (
-				!piece.instance.piece.userEditOperations?.find(
-					// (op) => op.type === UserEditingType.SOFIE && op.id === DefaultUserOperationsTypes.RETIME_PIECE
-					(op) => op.type === UserEditingType.SOFIE && op.id === '__sofie-retime-piece'
-				)
-			)
-				return
+			if (!hasDraggableElement) return
 
 			const targetPos = (e.target as HTMLDivElement).getBoundingClientRect()
-			if (dragCtx)
+			if (dragCtx && dragCtx.enabled)
 				dragCtx.startDrag(
 					piece,
 					timeScale,
@@ -223,7 +212,7 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 					part.instance.segmentId
 				)
 		},
-		[piece, timeScale]
+		[piece, timeScale, dragCtx]
 	)
 	const itemMouseUp = useCallback((e: any) => {
 		const eM = e as MouseEvent
@@ -614,8 +603,10 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 					layer.type,
 					part.partId,
 					highlight,
-					elementWidth
+					elementWidth,
 					// this.state
+					undefined,
+					hasDraggableElement && dragCtx?.enabled
 				)}
 				data-obj-id={piece.instance._id}
 				ref={setRef}

--- a/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react'
 import { ISourceLayerUi, IOutputLayerUi, PartUi, PieceUi } from './SegmentTimelineContainer.js'
-import { SourceLayerType, PieceLifespan, IBlueprintPieceType } from '@sofie-automation/blueprints-integration'
+import {
+	SourceLayerType,
+	PieceLifespan,
+	IBlueprintPieceType,
+	UserEditingType,
+	DefaultUserOperationsTypes,
+} from '@sofie-automation/blueprints-integration'
 import { RundownUtils } from '../../lib/rundown.js'
 import { DefaultLayerItemRenderer } from './Renderers/DefaultLayerItemRenderer.js'
 import { MicSourceRenderer } from './Renderers/MicSourceRenderer.js'
@@ -20,6 +26,7 @@ import { ReadonlyDeep } from 'type-fest'
 import { useSelectedElementsContext } from '../RundownView/SelectedElementsContext.js'
 import { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { useCallback, useRef, useState, useEffect, useContext } from 'react'
+import { dragContext } from '../RundownView/DragContext.js'
 import {
 	convertSourceLayerItemToPreview,
 	IPreviewPopUpSession,
@@ -114,6 +121,8 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 	const [leftAnchoredWidth, setLeftAnchoredWidth] = useState<number>(0)
 	const [rightAnchoredWidth, setRightAnchoredWidth] = useState<number>(0)
 
+	const dragCtx = useContext(dragContext)
+
 	const state = {
 		highlight,
 		showPreviewPopUp,
@@ -180,10 +189,42 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 		},
 		[piece]
 	)
-	const itemMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-		e.preventDefault()
-		e.stopPropagation()
-	}, [])
+	const itemMouseDown = useCallback(
+		(e: React.MouseEvent<HTMLDivElement>) => {
+			e.preventDefault()
+			e.stopPropagation()
+			console.log(
+				'mousedown',
+				UserEditingType.SOFIE,
+				DefaultUserOperationsTypes,
+				piece.instance.piece.userEditOperations?.map(
+					(op) => op.type === UserEditingType.SOFIE && op.id === '__sofie-retime-piece'
+				)
+			)
+
+			if (
+				!piece.instance.piece.userEditOperations?.find(
+					// (op) => op.type === UserEditingType.SOFIE && op.id === DefaultUserOperationsTypes.RETIME_PIECE
+					(op) => op.type === UserEditingType.SOFIE && op.id === '__sofie-retime-piece'
+				)
+			)
+				return
+
+			const targetPos = (e.target as HTMLDivElement).getBoundingClientRect()
+			if (dragCtx)
+				dragCtx.startDrag(
+					piece,
+					timeScale,
+					{
+						x: e.clientX,
+						y: e.clientY,
+					},
+					targetPos.x - e.clientX,
+					part.instance.segmentId
+				)
+		},
+		[piece, timeScale]
+	)
 	const itemMouseUp = useCallback((e: any) => {
 		const eM = e as MouseEvent
 		if (eM.ctrlKey === true) {

--- a/packages/webui/src/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
+++ b/packages/webui/src/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
@@ -93,6 +93,17 @@ function getArguments(t: TFunction, action: SomeAction): string[] {
 				assertNever(action.state)
 			}
 			break
+		case ClientActions.editMode:
+			if (action.state === true) {
+				result.push(t('Enable'))
+			} else if (action.state === false) {
+				result.push(t('Disable'))
+			} else if (action.state === 'toggle') {
+				result.push(t('Toggle'))
+			} else {
+				assertNever(action.state)
+			}
+			break
 		case ClientActions.goToOnAirLine:
 			break
 		case ClientActions.rewindSegments:
@@ -147,6 +158,8 @@ function hasArguments(action: SomeAction): boolean {
 			return false
 		case ClientActions.shelf:
 			return true
+		case ClientActions.editMode:
+			return true
 		case ClientActions.goToOnAirLine:
 			return false
 		case ClientActions.rewindSegments:
@@ -193,6 +206,8 @@ function actionToLabel(t: TFunction, action: SomeAction['action']): string {
 			return t('Switch Route Set')
 		case ClientActions.shelf:
 			return t('Shelf')
+		case ClientActions.editMode:
+			return t('Edit Mode')
 		case ClientActions.rewindSegments:
 			return t('Rewind Segments to start')
 		case ClientActions.goToOnAirLine:
@@ -358,6 +373,40 @@ function getActionParametersEditor(
 							},
 							{
 								name: t('Close'),
+								value: false,
+								i: 1,
+							},
+							{
+								name: t('Toggle'),
+								value: 'toggle',
+								i: 2,
+							},
+						]}
+						handleUpdate={(newVal) => {
+							onChange({
+								...action,
+								state: newVal,
+							})
+						}}
+					/>
+				</div>
+			)
+		case ClientActions.editMode:
+			return (
+				<div className="mts">
+					<label className="block">{t('State')}</label>
+					<DropdownInputControl<typeof action.state>
+						classNames="input text-input input-m"
+						value={action.state}
+						// placholder={t('State')}
+						options={[
+							{
+								name: t('Enable'),
+								value: true,
+								i: 0,
+							},
+							{
+								name: t('Disable'),
 								value: false,
 								i: 1,
 							},


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Feature.

## Current Behavior

Items in the timeline are fixed.

## New Behavior

If a piece has a `userEditOperation` of type `UserEditingType.SOFIE` and id `DefaultUserOperationsTypes.RETIME_PIECE` and editing is enabled, you can drag it around the timeline.

https://github.com/user-attachments/assets/bd509d37-b174-4609-a9b8-e8ebf01f8622

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

* This PR affects the timeline view
* This PR affects what blueprints can do

## Time Frame


## Other Information

This is a rebase of https://github.com/bbc/sofie-core/pull/35 to the current BBC release 53 with an extra commit to get better errors when a bad blueprint upload happens.

See also https://github.com/Sofie-Automation/sofie-core/pull/1544

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
