### PR TITLE
feat: HTTP api for controlling t-timers

### DIFF
--- a/meteor/server/api/rest/v1/__tests__/playlists.spec.ts
+++ b/meteor/server/api/rest/v1/__tests__/playlists.spec.ts
@@ -1,0 +1,77 @@
+import { registerRoutes } from '../playlists'
+import { ClientAPI } from '@sofie-automation/meteor-lib/dist/api/client'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { PlaylistsRestAPI } from '../../../../lib/rest/v1'
+
+describe('Playlists REST API Routes', () => {
+	let mockRegisterRoute: jest.Mock
+	let mockServerAPI: jest.Mocked<PlaylistsRestAPI>
+
+	beforeEach(() => {
+		mockRegisterRoute = jest.fn()
+		mockServerAPI = {
+			tTimerStartCountdown: jest.fn().mockResolvedValue(ClientAPI.responseSuccess(undefined)),
+			tTimerStartFreeRun: jest.fn().mockResolvedValue(ClientAPI.responseSuccess(undefined)),
+			tTimerPause: jest.fn().mockResolvedValue(ClientAPI.responseSuccess(undefined)),
+			tTimerResume: jest.fn().mockResolvedValue(ClientAPI.responseSuccess(undefined)),
+			tTimerRestart: jest.fn().mockResolvedValue(ClientAPI.responseSuccess(undefined)),
+		} as any
+
+		registerRoutes(mockRegisterRoute)
+	})
+
+	test('should register T-timer countdown route', () => {
+		const countdownRoute = mockRegisterRoute.mock.calls.find(
+			(call) => call[1] === '/playlists/:playlistId/t-timers/:timerIndex/countdown'
+		)
+		expect(countdownRoute).toBeDefined()
+		expect(countdownRoute[0]).toBe('post')
+	})
+
+	test('T-timer countdown handler should call serverAPI.tTimerStartCountdown', async () => {
+		const countdownRoute = mockRegisterRoute.mock.calls.find(
+			(call) => call[1] === '/playlists/:playlistId/t-timers/:timerIndex/countdown'
+		)
+		const handler = countdownRoute[4]
+
+		const params = { playlistId: 'playlist0', timerIndex: '1' }
+		const body = { duration: 60, stopAtZero: true, startPaused: false }
+		const connection = {} as any
+		const event = 'test-event'
+
+		await handler(mockServerAPI, connection, event, params, body)
+
+		expect(mockServerAPI.tTimerStartCountdown).toHaveBeenCalledWith(
+			connection,
+			event,
+			protectString('playlist0'),
+			1,
+			60,
+			true,
+			false
+		)
+	})
+
+	test('should register T-timer pause route', () => {
+		const pauseRoute = mockRegisterRoute.mock.calls.find(
+			(call) => call[1] === '/playlists/:playlistId/t-timers/:timerIndex/pause'
+		)
+		expect(pauseRoute).toBeDefined()
+		expect(pauseRoute[0]).toBe('post')
+	})
+
+	test('T-timer pause handler should call serverAPI.tTimerPause', async () => {
+		const pauseRoute = mockRegisterRoute.mock.calls.find(
+			(call) => call[1] === '/playlists/:playlistId/t-timers/:timerIndex/pause'
+		)
+		const handler = pauseRoute[4]
+
+		const params = { playlistId: 'playlist0', timerIndex: '2' }
+		const connection = {} as any
+		const event = 'test-event'
+
+		await handler(mockServerAPI, connection, event, params, {})
+
+		expect(mockServerAPI.tTimerPause).toHaveBeenCalledWith(connection, event, protectString('playlist0'), 2)
+	})
+})

--- a/meteor/server/lib/rest/v1/playlists.ts
+++ b/meteor/server/lib/rest/v1/playlists.ts
@@ -11,6 +11,7 @@ import {
 	SegmentId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { QueueNextSegmentResult } from '@sofie-automation/corelib/dist/worker/studio'
+import { RundownTTimerIndex } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { Meteor } from 'meteor/meteor'
 
 /* *************************************************************************
@@ -260,5 +261,79 @@ export interface PlaylistsRestAPI {
 		event: string,
 		rundownPlaylistId: RundownPlaylistId,
 		sourceLayerId: string
+	): Promise<ClientAPI.ClientResponse<void>>
+	/**
+	 * Configure a T-timer as a countdown.
+	 * @param connection Connection data including client and header details
+	 * @param event User event string
+	 * @param rundownPlaylistId Target Playlist.
+	 * @param timerIndex Index of the timer (1-3).
+	 * @param duration Duration in seconds.
+	 * @param stopAtZero Whether to stop at zero.
+	 * @param startPaused Whether to start paused.
+	 */
+	tTimerStartCountdown(
+		connection: Meteor.Connection,
+		event: string,
+		rundownPlaylistId: RundownPlaylistId,
+		timerIndex: RundownTTimerIndex,
+		duration: number,
+		stopAtZero?: boolean,
+		startPaused?: boolean
+	): Promise<ClientAPI.ClientResponse<void>>
+
+	/**
+	 * Configure a T-timer as a free-running timer.
+	 * @param connection Connection data including client and header details
+	 * @param event User event string
+	 * @param rundownPlaylistId Target Playlist.
+	 * @param timerIndex Index of the timer (1-3).
+	 * @param startPaused Whether to start paused.
+	 */
+	tTimerStartFreeRun(
+		connection: Meteor.Connection,
+		event: string,
+		rundownPlaylistId: RundownPlaylistId,
+		timerIndex: RundownTTimerIndex,
+		startPaused?: boolean
+	): Promise<ClientAPI.ClientResponse<void>>
+	/**
+	 * Pause a T-timer.
+	 * @param connection Connection data including client and header details
+	 * @param event User event string
+	 * @param rundownPlaylistId Target Playlist.
+	 * @param timerIndex Index of the timer (1-3).
+	 */
+	tTimerPause(
+		connection: Meteor.Connection,
+		event: string,
+		rundownPlaylistId: RundownPlaylistId,
+		timerIndex: RundownTTimerIndex
+	): Promise<ClientAPI.ClientResponse<void>>
+	/**
+	 * Resume a T-timer.
+	 * @param connection Connection data including client and header details
+	 * @param event User event string
+	 * @param rundownPlaylistId Target Playlist.
+	 * @param timerIndex Index of the timer (1-3).
+	 */
+	tTimerResume(
+		connection: Meteor.Connection,
+		event: string,
+		rundownPlaylistId: RundownPlaylistId,
+		timerIndex: RundownTTimerIndex
+	): Promise<ClientAPI.ClientResponse<void>>
+	/**
+	 * Restart a T-timer.
+	 * @param connection Connection data including client and header details
+	 * @param event User event string
+	 * @param rundownPlaylistId Target Playlist.
+	 * @param timerIndex Index of the timer (1-3).
+	 */
+	tTimerRestart(
+		connection: Meteor.Connection,
+		event: string,
+		rundownPlaylistId: RundownPlaylistId,
+		timerIndex: RundownTTimerIndex
 	): Promise<ClientAPI.ClientResponse<void>>
 }

--- a/packages/corelib/src/worker/studio.ts
+++ b/packages/corelib/src/worker/studio.ts
@@ -19,7 +19,7 @@ import { JSONBlob } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 import { CoreRundownPlaylistSnapshot } from '../snapshots.js'
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { ITranslatableMessage } from '../TranslatableMessage.js'
-import { QuickLoopMarker } from '../dataModel/RundownPlaylist.js'
+import { QuickLoopMarker, RundownTTimerIndex } from '../dataModel/RundownPlaylist.js'
 
 /** List of all Jobs performed by the Worker related to a certain Studio */
 export enum StudioJobs {
@@ -211,6 +211,28 @@ export enum StudioJobs {
 	 * During playout it is hard to track removal of PieceInstances (particularly when resetting PieceInstances)
 	 */
 	CleanupOrphanedExpectedPackageReferences = 'cleanupOrphanedExpectedPackageReferences',
+
+	/**
+	 * Configure a T-timer as a countdown
+	 */
+	TTimerStartCountdown = 'tTimerStartCountdown',
+
+	/**
+	 * Configure a T-timer as a free-running timer
+	 */
+	TTimerStartFreeRun = 'tTimerStartFreeRun',
+	/**
+	 * Pause a T-timer
+	 */
+	TTimerPause = 'tTimerPause',
+	/**
+	 * Resume a T-timer
+	 */
+	TTimerResume = 'tTimerResume',
+	/**
+	 * Restart a T-timer
+	 */
+	TTimerRestart = 'tTimerRestart',
 }
 
 export interface RundownPlayoutPropsBase {
@@ -374,6 +396,21 @@ export interface SwitchRouteSetProps {
 	routeSetId: string
 	state: boolean | 'toggle'
 }
+export interface TTimerPropsBase extends RundownPlayoutPropsBase {
+	timerIndex: RundownTTimerIndex
+}
+export interface TTimerStartCountdownProps extends TTimerPropsBase {
+	duration: number
+	stopAtZero: boolean
+	startPaused: boolean
+}
+
+export interface TTimerStartFreeRunProps extends TTimerPropsBase {
+	startPaused: boolean
+}
+export type TTimerPauseProps = TTimerPropsBase
+export type TTimerResumeProps = TTimerPropsBase
+export type TTimerRestartProps = TTimerPropsBase
 
 export interface CleanupOrphanedExpectedPackageReferencesProps {
 	playlistId: RundownPlaylistId
@@ -438,6 +475,12 @@ export type StudioJobFunc = {
 	[StudioJobs.SwitchRouteSet]: (data: SwitchRouteSetProps) => void
 
 	[StudioJobs.CleanupOrphanedExpectedPackageReferences]: (data: CleanupOrphanedExpectedPackageReferencesProps) => void
+	[StudioJobs.TTimerStartCountdown]: (data: TTimerStartCountdownProps) => void
+
+	[StudioJobs.TTimerStartFreeRun]: (data: TTimerStartFreeRunProps) => void
+	[StudioJobs.TTimerPause]: (data: TTimerPauseProps) => void
+	[StudioJobs.TTimerResume]: (data: TTimerResumeProps) => void
+	[StudioJobs.TTimerRestart]: (data: TTimerRestartProps) => void
 }
 
 export function getStudioQueueName(id: StudioId): string {

--- a/packages/job-worker/src/playout/tTimersJobs.ts
+++ b/packages/job-worker/src/playout/tTimersJobs.ts
@@ -20,15 +20,13 @@ export async function handleTTimerStartCountdown(_context: JobContext, data: TTi
 	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
 		validateTTimerIndex(data.timerIndex)
 
-		const timerMode = createCountdownTTimer(data.duration * 1000, {
-			stopAtZero: data.stopAtZero,
-			startPaused: data.startPaused,
-		})
-
 		const currentTimer = playoutModel.playlist.tTimers[data.timerIndex - 1]
 		playoutModel.updateTTimer({
 			...currentTimer,
-			mode: timerMode,
+			...createCountdownTTimer(data.duration * 1000, {
+				stopAtZero: data.stopAtZero,
+				startPaused: data.startPaused,
+			}),
 		})
 	})
 }
@@ -37,14 +35,12 @@ export async function handleTTimerStartFreeRun(_context: JobContext, data: TTime
 	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
 		validateTTimerIndex(data.timerIndex)
 
-		const timerMode = createFreeRunTTimer({
-			startPaused: data.startPaused,
-		})
-
 		const currentTimer = playoutModel.playlist.tTimers[data.timerIndex - 1]
 		playoutModel.updateTTimer({
 			...currentTimer,
-			mode: timerMode,
+			...createFreeRunTTimer({
+				startPaused: data.startPaused,
+			}),
 		})
 	})
 }
@@ -57,12 +53,9 @@ export async function handleTTimerPause(_context: JobContext, data: TTimerPauseP
 		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
 		if (!currentTimer.mode) return
 
-		const newMode = pauseTTimer(currentTimer.mode)
-		if (newMode) {
-			playoutModel.updateTTimer({
-				...currentTimer,
-				mode: newMode,
-			})
+		const updatedTimer = pauseTTimer(currentTimer)
+		if (updatedTimer) {
+			playoutModel.updateTTimer(updatedTimer)
 		}
 	})
 }
@@ -75,12 +68,9 @@ export async function handleTTimerResume(_context: JobContext, data: TTimerResum
 		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
 		if (!currentTimer.mode) return
 
-		const newMode = resumeTTimer(currentTimer.mode)
-		if (newMode) {
-			playoutModel.updateTTimer({
-				...currentTimer,
-				mode: newMode,
-			})
+		const updatedTimer = resumeTTimer(currentTimer)
+		if (updatedTimer) {
+			playoutModel.updateTTimer(updatedTimer)
 		}
 	})
 }
@@ -93,12 +83,9 @@ export async function handleTTimerRestart(_context: JobContext, data: TTimerRest
 		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
 		if (!currentTimer.mode) return
 
-		const newMode = restartTTimer(currentTimer.mode)
-		if (newMode) {
-			playoutModel.updateTTimer({
-				...currentTimer,
-				mode: newMode,
-			})
+		const updatedTimer = restartTTimer(currentTimer)
+		if (updatedTimer) {
+			playoutModel.updateTTimer(updatedTimer)
 		}
 	})
 }

--- a/packages/job-worker/src/playout/tTimersJobs.ts
+++ b/packages/job-worker/src/playout/tTimersJobs.ts
@@ -1,0 +1,104 @@
+import {
+	TTimerPauseProps,
+	TTimerRestartProps,
+	TTimerResumeProps,
+	TTimerStartCountdownProps,
+	TTimerStartFreeRunProps,
+} from '@sofie-automation/corelib/dist/worker/studio'
+import { JobContext } from '../jobs/index.js'
+import { runJobWithPlayoutModel } from './lock.js'
+import {
+	createCountdownTTimer,
+	createFreeRunTTimer,
+	pauseTTimer,
+	restartTTimer,
+	resumeTTimer,
+	validateTTimerIndex,
+} from './tTimers.js'
+
+export async function handleTTimerStartCountdown(_context: JobContext, data: TTimerStartCountdownProps): Promise<void> {
+	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
+		validateTTimerIndex(data.timerIndex)
+
+		const timerMode = createCountdownTTimer(data.duration * 1000, {
+			stopAtZero: data.stopAtZero,
+			startPaused: data.startPaused,
+		})
+
+		const currentTimer = playoutModel.playlist.tTimers[data.timerIndex - 1]
+		playoutModel.updateTTimer({
+			...currentTimer,
+			mode: timerMode,
+		})
+	})
+}
+
+export async function handleTTimerStartFreeRun(_context: JobContext, data: TTimerStartFreeRunProps): Promise<void> {
+	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
+		validateTTimerIndex(data.timerIndex)
+
+		const timerMode = createFreeRunTTimer({
+			startPaused: data.startPaused,
+		})
+
+		const currentTimer = playoutModel.playlist.tTimers[data.timerIndex - 1]
+		playoutModel.updateTTimer({
+			...currentTimer,
+			mode: timerMode,
+		})
+	})
+}
+
+export async function handleTTimerPause(_context: JobContext, data: TTimerPauseProps): Promise<void> {
+	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
+		validateTTimerIndex(data.timerIndex)
+
+		const timerIndex = data.timerIndex - 1
+		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
+		if (!currentTimer.mode) return
+
+		const newMode = pauseTTimer(currentTimer.mode)
+		if (newMode) {
+			playoutModel.updateTTimer({
+				...currentTimer,
+				mode: newMode,
+			})
+		}
+	})
+}
+
+export async function handleTTimerResume(_context: JobContext, data: TTimerResumeProps): Promise<void> {
+	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
+		validateTTimerIndex(data.timerIndex)
+
+		const timerIndex = data.timerIndex - 1
+		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
+		if (!currentTimer.mode) return
+
+		const newMode = resumeTTimer(currentTimer.mode)
+		if (newMode) {
+			playoutModel.updateTTimer({
+				...currentTimer,
+				mode: newMode,
+			})
+		}
+	})
+}
+
+export async function handleTTimerRestart(_context: JobContext, data: TTimerRestartProps): Promise<void> {
+	return runJobWithPlayoutModel(_context, data, null, async (playoutModel) => {
+		validateTTimerIndex(data.timerIndex)
+
+		const timerIndex = data.timerIndex - 1
+		const currentTimer = playoutModel.playlist.tTimers[timerIndex]
+		if (!currentTimer.mode) return
+
+		const newMode = restartTTimer(currentTimer.mode)
+		if (newMode) {
+			playoutModel.updateTTimer({
+				...currentTimer,
+				mode: newMode,
+			})
+		}
+	})
+}

--- a/packages/job-worker/src/workers/studio/jobs.ts
+++ b/packages/job-worker/src/workers/studio/jobs.ts
@@ -49,6 +49,13 @@ import { handleActivateAdlibTesting } from '../../playout/adlibTesting.js'
 import { handleExecuteBucketAdLibOrAction } from '../../playout/bucketAdlibJobs.js'
 import { handleSwitchRouteSet } from '../../studio/routeSet.js'
 import { handleCleanupOrphanedExpectedPackageReferences } from '../../playout/expectedPackages.js'
+import {
+	handleTTimerPause,
+	handleTTimerRestart,
+	handleTTimerResume,
+	handleTTimerStartCountdown,
+	handleTTimerStartFreeRun,
+} from '../../playout/tTimersJobs.js'
 
 type ExecutableFunction<T extends keyof StudioJobFunc> = (
 	context: JobContext,
@@ -113,4 +120,11 @@ export const studioJobHandlers: StudioJobHandlers = {
 	[StudioJobs.SwitchRouteSet]: handleSwitchRouteSet,
 
 	[StudioJobs.CleanupOrphanedExpectedPackageReferences]: handleCleanupOrphanedExpectedPackageReferences,
+
+	[StudioJobs.TTimerStartCountdown]: handleTTimerStartCountdown,
+
+	[StudioJobs.TTimerStartFreeRun]: handleTTimerStartFreeRun,
+	[StudioJobs.TTimerPause]: handleTTimerPause,
+	[StudioJobs.TTimerResume]: handleTTimerResume,
+	[StudioJobs.TTimerRestart]: handleTTimerRestart,
 }

--- a/packages/openapi/api/actions.yaml
+++ b/packages/openapi/api/actions.yaml
@@ -71,6 +71,17 @@ paths:
     $ref: 'definitions/playlists.yaml#/resources/sourceLayer'
   /playlists/{playlistId}/sourceLayer/{sourceLayerId}/sticky:
     $ref: 'definitions/playlists.yaml#/resources/sourceLayer/sticky'
+  /playlists/{playlistId}/t-timers/{timerIndex}/countdown:
+    $ref: 'definitions/playlists.yaml#/resources/tTimerCountdown'
+
+  /playlists/{playlistId}/t-timers/{timerIndex}/free-run:
+    $ref: 'definitions/playlists.yaml#/resources/tTimerFreeRun'
+  /playlists/{playlistId}/t-timers/{timerIndex}/pause:
+    $ref: 'definitions/playlists.yaml#/resources/tTimerPause'
+  /playlists/{playlistId}/t-timers/{timerIndex}/resume:
+    $ref: 'definitions/playlists.yaml#/resources/tTimerResume'
+  /playlists/{playlistId}/t-timers/{timerIndex}/restart:
+    $ref: 'definitions/playlists.yaml#/resources/tTimerRestart'
   # studio operations
   /studios:
     $ref: 'definitions/studios.yaml#/resources/studios'

--- a/packages/openapi/api/definitions/playlists.yaml
+++ b/packages/openapi/api/definitions/playlists.yaml
@@ -714,6 +714,169 @@ resources:
                       example: Rundown must be active!
           500:
             $ref: '#/components/responses/internalServerError'
+  tTimerCountdown:
+    post:
+      operationId: tTimerCountdown
+      tags:
+        - playlists
+      summary: Start a countdown timer.
+      parameters:
+        - name: playlistId
+          in: path
+          description: Target playlist.
+          required: true
+          schema:
+            type: string
+        - name: timerIndex
+          in: path
+          description: Index of the timer (1, 2, or 3).
+          required: true
+          schema:
+            type: integer
+            enum: [1, 2, 3]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                duration:
+                  type: number
+                  description: Duration in seconds.
+                stopAtZero:
+                  type: boolean
+                  description: Whether to stop the timer at zero.
+                startPaused:
+                  type: boolean
+                  description: Whether to start the timer in a paused state.
+              required:
+                - duration
+      responses:
+        200:
+          $ref: '#/components/responses/putSuccess'
+        404:
+          $ref: '#/components/responses/playlistNotFound'
+        500:
+          $ref: '#/components/responses/internalServerError'
+
+  tTimerFreeRun:
+    post:
+      operationId: tTimerFreeRun
+      tags:
+        - playlists
+      summary: Start a free-running timer.
+      parameters:
+        - name: playlistId
+          in: path
+          description: Target playlist.
+          required: true
+          schema:
+            type: string
+        - name: timerIndex
+          in: path
+          description: Index of the timer (1, 2, or 3).
+          required: true
+          schema:
+            type: integer
+            enum: [1, 2, 3]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                startPaused:
+                  type: boolean
+                  description: Whether to start the timer in a paused state.
+      responses:
+        200:
+          $ref: '#/components/responses/putSuccess'
+        404:
+          $ref: '#/components/responses/playlistNotFound'
+        500:
+          $ref: '#/components/responses/internalServerError'
+  tTimerPause:
+    post:
+      operationId: tTimerPause
+      tags:
+        - playlists
+      summary: Pause a timer.
+      parameters:
+        - name: playlistId
+          in: path
+          description: Target playlist.
+          required: true
+          schema:
+            type: string
+        - name: timerIndex
+          in: path
+          description: Index of the timer (1, 2, or 3).
+          required: true
+          schema:
+            type: integer
+            enum: [1, 2, 3]
+      responses:
+        200:
+          $ref: '#/components/responses/putSuccess'
+        404:
+          $ref: '#/components/responses/playlistNotFound'
+        500:
+          $ref: '#/components/responses/internalServerError'
+  tTimerResume:
+    post:
+      operationId: tTimerResume
+      tags:
+        - playlists
+      summary: Resume a timer.
+      parameters:
+        - name: playlistId
+          in: path
+          description: Target playlist.
+          required: true
+          schema:
+            type: string
+        - name: timerIndex
+          in: path
+          description: Index of the timer (1, 2, or 3).
+          required: true
+          schema:
+            type: integer
+            enum: [1, 2, 3]
+      responses:
+        200:
+          $ref: '#/components/responses/putSuccess'
+        404:
+          $ref: '#/components/responses/playlistNotFound'
+        500:
+          $ref: '#/components/responses/internalServerError'
+  tTimerRestart:
+    post:
+      operationId: tTimerRestart
+      tags:
+        - playlists
+      summary: Restart a timer.
+      parameters:
+        - name: playlistId
+          in: path
+          description: Target playlist.
+          required: true
+          schema:
+            type: string
+        - name: timerIndex
+          in: path
+          description: Index of the timer (1, 2, or 3).
+          required: true
+          schema:
+            type: integer
+            enum: [1, 2, 3]
+      responses:
+        200:
+          $ref: '#/components/responses/putSuccess'
+        404:
+          $ref: '#/components/responses/playlistNotFound'
+        500:
+          $ref: '#/components/responses/internalServerError'
 
 components:
   schemas:


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:

<!-- (pick one) -->

Feature

## Current Behavior

Currently, the t-timers functionality can be only controlled from the blueprints and from within sofie-core components internally. 

## New Behavior

This PR makes it possible to control t-timers using a new RESTful HTTP API. It exposes the write methods, as reads will be handled by connecting to LSG,

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

We intend to finish the development on this feature in one week (until R53 is frozen)

## Other Information

**Note: this PR is waiting for #67 to be merged**

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
