### PR TITLE
T-Timers pause time (on hold)

### DIFF
--- a/packages/blueprints-integration/src/context/tTimersContext.ts
+++ b/packages/blueprints-integration/src/context/tTimersContext.ts
@@ -71,6 +71,42 @@ export interface IPlaylistTTimer {
 	 * @returns True if the timer was restarted, false if it could not be restarted
 	 */
 	restart(): boolean
+
+	/**
+	 * Clear any estimate (manual or anchor-based) for this timer
+	 * This removes both manual estimates set via setEstimateTime/setEstimateDuration
+	 * and automatic estimates based on anchor parts set via setEstimateAnchorPart.
+	 */
+	clearEstimate(): void
+
+	/**
+	 * Set the anchor part for automatic estimate calculation
+	 * When set, the server automatically calculates when we expect to reach this part
+	 * based on remaining part durations, and updates the estimate accordingly.
+	 * Clears any manual estimate set via setEstimateTime/setEstimateDuration.
+	 * @param partId The ID of the part to use as timing anchor
+	 */
+	setEstimateAnchorPart(partId: string): void
+
+	/**
+	 * Manually set the estimate as an absolute timestamp
+	 * Use this when you have custom logic for calculating when you expect to reach a timing point.
+	 * Clears any anchor part set via setAnchorPart.
+	 * @param time Unix timestamp (milliseconds) when we expect to reach the timing point
+	 * @param paused If true, we're currently delayed/pushing (estimate won't update with time passing).
+	 *               If false (default), we're progressing normally (estimate counts down in real-time).
+	 */
+	setEstimateTime(time: number, paused?: boolean): void
+
+	/**
+	 * Manually set the estimate as a relative duration from now
+	 * Use this when you want to express the estimate as "X milliseconds from now".
+	 * Clears any anchor part set via setAnchorPart.
+	 * @param duration Milliseconds until we expect to reach the timing point
+	 * @param paused If true, we're currently delayed/pushing (estimate won't update with time passing).
+	 *               If false (default), we're progressing normally (estimate counts down in real-time).
+	 */
+	setEstimateDuration(duration: number, paused?: boolean): void
 }
 
 export type IPlaylistTTimerState =

--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -164,6 +164,27 @@ export type TimerState =
 			pauseTime?: number | null
 	  }
 
+/**
+ * Calculate the current duration for a timer state.
+ * Handles paused, auto-pause (pauseTime), and running states.
+ *
+ * @param state The timer state
+ * @param now Current timestamp in milliseconds
+ * @returns The current duration in milliseconds
+ */
+export function timerStateToDuration(state: TimerState, now: number): number {
+	if (state.paused) {
+		// Manually paused by user or already pushing/overrun
+		return state.duration
+	} else if (state.pauseTime && now >= state.pauseTime) {
+		// Auto-pause at overrun (current part ended)
+		return state.zeroTime - state.pauseTime
+	} else {
+		// Running normally
+		return state.zeroTime - now
+	}
+}
+
 export type RundownTTimerIndex = 1 | 2 | 3
 
 export interface RundownTTimer {

--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -165,6 +165,26 @@ export interface RundownTTimer {
 	 */
 	state: TimerState | null
 
+	/** The estimated time when we expect to reach the anchor part, for calculating over/under diff.
+	 *
+	 * Based on scheduled durations of remaining parts and segments up to the anchor.
+	 * The over/under diff is calculated as the difference between this estimate and the timer's target (state.zeroTime).
+	 *
+	 * Running means we are progressing towards the anchor (estimate moves with real time)
+	 * Paused means we are pushing (e.g. overrunning the current segment, so the anchor is being delayed)
+	 *
+	 * Calculated automatically when anchorPartId is set, or can be set manually by a blueprint if custom logic is needed.
+	 */
+	estimateState?: TimerState
+
+	/** The target Part that this timer is counting towards (the "timing anchor")
+	 *
+	 * This is typically a "break" part or other milestone in the rundown.
+	 * When set, the server calculates estimateState based on when we expect to reach this part.
+	 * If not set, estimateState is not calculated automatically but can still be set manually by a blueprint.
+	 */
+	anchorPartId?: PartId
+
 	/*
 	 * Future ideas:
 	 * allowUiControl: boolean

--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -131,6 +131,20 @@ export interface RundownTTimerModeTimeOfDay {
  * When running, the client calculates current time from zeroTime.
  * When paused, the duration is frozen and sent directly.
  * pauseTime indicates when the timer should automatically pause (when current part ends and overrun begins).
+ *
+ * Client rendering logic:
+ * ```typescript
+ * if (state.paused === true) {
+ *   // Manually paused by user or already pushing/overrun
+ *   duration = state.duration
+ * } else if (state.pauseTime && now >= state.pauseTime) {
+ *   // Auto-pause at overrun (current part ended)
+ *   duration = state.zeroTime - state.pauseTime
+ * } else {
+ *   // Running normally
+ *   duration = state.zeroTime - now
+ * }
+ * ```
  */
 export type TimerState =
 	| {

--- a/packages/corelib/src/dataModel/RundownPlaylist.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist.ts
@@ -130,6 +130,7 @@ export interface RundownTTimerModeTimeOfDay {
  * Timing state for a timer, optimized for efficient client rendering.
  * When running, the client calculates current time from zeroTime.
  * When paused, the duration is frozen and sent directly.
+ * pauseTime indicates when the timer should automatically pause (when current part ends and overrun begins).
  */
 export type TimerState =
 	| {
@@ -137,12 +138,16 @@ export type TimerState =
 			paused: false
 			/** The absolute timestamp (ms) when the timer reaches/reached zero */
 			zeroTime: number
+			/** Optional timestamp when the timer should pause (when current part ends) */
+			pauseTime?: number | null
 	  }
 	| {
 			/** Whether the timer is paused */
 			paused: true
 			/** The frozen duration value in milliseconds */
 			duration: number
+			/** Optional timestamp when the timer should pause (null when already paused/pushing) */
+			pauseTime?: number | null
 	  }
 
 export type RundownTTimerIndex = 1 | 2 | 3

--- a/packages/corelib/src/worker/studio.ts
+++ b/packages/corelib/src/worker/studio.ts
@@ -127,6 +127,12 @@ export enum StudioJobs {
 	OnTimelineTriggerTime = 'onTimelineTriggerTime',
 
 	/**
+	 * Recalculate T-Timer estimates based on current playlist state
+	 * Called after setNext, takes, and ingest changes to update timing anchor estimates
+	 */
+	RecalculateTTimerEstimates = 'recalculateTTimerEstimates',
+
+	/**
 	 * Update the timeline with a regenerated Studio Baseline
 	 * Has no effect if a Playlist is active
 	 */
@@ -411,6 +417,8 @@ export type StudioJobFunc = {
 
 	[StudioJobs.OnPlayoutPlaybackChanged]: (data: OnPlayoutPlaybackChangedProps) => void
 	[StudioJobs.OnTimelineTriggerTime]: (data: OnTimelineTriggerTimeProps) => void
+
+	[StudioJobs.RecalculateTTimerEstimates]: () => void
 
 	[StudioJobs.UpdateStudioBaseline]: () => string | false
 	[StudioJobs.CleanupEmptyPlaylists]: () => void

--- a/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
@@ -50,7 +50,7 @@ export class OnSetAsNextContext
 		public readonly manuallySelected: boolean
 	) {
 		super(contextInfo, context, showStyle, watchedPackages)
-		this.#tTimersService = TTimersService.withPlayoutModel(playoutModel)
+		this.#tTimersService = TTimersService.withPlayoutModel(playoutModel, context)
 	}
 
 	public get quickLoopInfo(): BlueprintQuickLookInfo | null {

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -66,7 +66,7 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 	) {
 		super(contextInfo, _context, showStyle, watchedPackages)
 		this.isTakeAborted = false
-		this.#tTimersService = TTimersService.withPlayoutModel(_playoutModel)
+		this.#tTimersService = TTimersService.withPlayoutModel(_playoutModel, _context)
 	}
 
 	async getUpcomingParts(limit: number = 5): Promise<ReadonlyDeep<IBlueprintPart[]>> {

--- a/packages/job-worker/src/blueprints/context/RundownActivationContext.ts
+++ b/packages/job-worker/src/blueprints/context/RundownActivationContext.ts
@@ -48,7 +48,7 @@ export class RundownActivationContext extends RundownEventContext implements IRu
 		this._previousState = options.previousState
 		this._currentState = options.currentState
 
-		this.#tTimersService = TTimersService.withPlayoutModel(this._playoutModel)
+		this.#tTimersService = TTimersService.withPlayoutModel(this._playoutModel, this._context)
 	}
 
 	get previousState(): IRundownActivationContextState {

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -117,7 +117,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		private readonly partAndPieceInstanceService: PartAndPieceInstanceActionService
 	) {
 		super(contextInfo, _context, showStyle, watchedPackages)
-		this.#tTimersService = TTimersService.withPlayoutModel(_playoutModel)
+		this.#tTimersService = TTimersService.withPlayoutModel(_playoutModel, _context)
 	}
 
 	async getUpcomingParts(limit: number = 5): Promise<ReadonlyDeep<IBlueprintPart[]>> {

--- a/packages/job-worker/src/blueprints/context/services/TTimersService.ts
+++ b/packages/job-worker/src/blueprints/context/services/TTimersService.ts
@@ -3,7 +3,10 @@ import type {
 	IPlaylistTTimerState,
 } from '@sofie-automation/blueprints-integration/dist/context/tTimersContext'
 import type { RundownTTimer, RundownTTimerIndex } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
-import { assertNever } from '@sofie-automation/corelib/dist/lib'
+import type { TimerState } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import type { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { assertNever, literal } from '@sofie-automation/corelib/dist/lib'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import type { PlayoutModel } from '../../../playout/model/PlayoutModel.js'
 import { ReadonlyDeep } from 'type-fest'
 import {
@@ -14,27 +17,36 @@ import {
 	restartTTimer,
 	resumeTTimer,
 	validateTTimerIndex,
+	recalculateTTimerEstimates,
 } from '../../../playout/tTimers.js'
 import { getCurrentTime } from '../../../lib/time.js'
+import type { JobContext } from '../../../jobs/index.js'
 
 export class TTimersService {
 	readonly timers: [PlaylistTTimerImpl, PlaylistTTimerImpl, PlaylistTTimerImpl]
 
 	constructor(
 		timers: ReadonlyDeep<RundownTTimer[]>,
-		emitChange: (updatedTimer: ReadonlyDeep<RundownTTimer>) => void
+		emitChange: (updatedTimer: ReadonlyDeep<RundownTTimer>) => void,
+		playoutModel: PlayoutModel,
+		jobContext: JobContext
 	) {
 		this.timers = [
-			new PlaylistTTimerImpl(timers[0], emitChange),
-			new PlaylistTTimerImpl(timers[1], emitChange),
-			new PlaylistTTimerImpl(timers[2], emitChange),
+			new PlaylistTTimerImpl(timers[0], emitChange, playoutModel, jobContext),
+			new PlaylistTTimerImpl(timers[1], emitChange, playoutModel, jobContext),
+			new PlaylistTTimerImpl(timers[2], emitChange, playoutModel, jobContext),
 		]
 	}
 
-	static withPlayoutModel(playoutModel: PlayoutModel): TTimersService {
-		return new TTimersService(playoutModel.playlist.tTimers, (updatedTimer) => {
-			playoutModel.updateTTimer(updatedTimer)
-		})
+	static withPlayoutModel(playoutModel: PlayoutModel, jobContext: JobContext): TTimersService {
+		return new TTimersService(
+			playoutModel.playlist.tTimers,
+			(updatedTimer) => {
+				playoutModel.updateTTimer(updatedTimer)
+			},
+			playoutModel,
+			jobContext
+		)
 	}
 
 	getTimer(index: RundownTTimerIndex): IPlaylistTTimer {
@@ -50,6 +62,8 @@ export class TTimersService {
 
 export class PlaylistTTimerImpl implements IPlaylistTTimer {
 	readonly #emitChange: (updatedTimer: ReadonlyDeep<RundownTTimer>) => void
+	readonly #playoutModel: PlayoutModel
+	readonly #jobContext: JobContext
 
 	#timer: ReadonlyDeep<RundownTTimer>
 
@@ -96,9 +110,18 @@ export class PlaylistTTimerImpl implements IPlaylistTTimer {
 		}
 	}
 
-	constructor(timer: ReadonlyDeep<RundownTTimer>, emitChange: (updatedTimer: ReadonlyDeep<RundownTTimer>) => void) {
+	constructor(
+		timer: ReadonlyDeep<RundownTTimer>,
+		emitChange: (updatedTimer: ReadonlyDeep<RundownTTimer>) => void,
+		playoutModel: PlayoutModel,
+		jobContext: JobContext
+	) {
 		this.#timer = timer
 		this.#emitChange = emitChange
+		this.#playoutModel = playoutModel
+		this.#jobContext = jobContext
+
+		validateTTimerIndex(timer.index)
 	}
 
 	setLabel(label: string): void {
@@ -167,5 +190,52 @@ export class PlaylistTTimerImpl implements IPlaylistTTimer {
 		this.#timer = newTimer
 		this.#emitChange(newTimer)
 		return true
+	}
+
+	clearEstimate(): void {
+		this.#timer = {
+			...this.#timer,
+			anchorPartId: undefined,
+			estimateState: undefined,
+		}
+		this.#emitChange(this.#timer)
+	}
+
+	setEstimateAnchorPart(partId: string): void {
+		this.#timer = {
+			...this.#timer,
+			anchorPartId: protectString<PartId>(partId),
+			estimateState: undefined, // Clear manual estimate
+		}
+		this.#emitChange(this.#timer)
+
+		// Recalculate estimates immediately since we already have the playout model
+		recalculateTTimerEstimates(this.#jobContext, this.#playoutModel)
+	}
+
+	setEstimateTime(time: number, paused: boolean = false): void {
+		const estimateState: TimerState = paused
+			? literal<TimerState>({ paused: true, duration: time - getCurrentTime() })
+			: literal<TimerState>({ paused: false, zeroTime: time })
+
+		this.#timer = {
+			...this.#timer,
+			anchorPartId: undefined, // Clear automatic anchor
+			estimateState,
+		}
+		this.#emitChange(this.#timer)
+	}
+
+	setEstimateDuration(duration: number, paused: boolean = false): void {
+		const estimateState: TimerState = paused
+			? literal<TimerState>({ paused: true, duration })
+			: literal<TimerState>({ paused: false, zeroTime: getCurrentTime() + duration })
+
+		this.#timer = {
+			...this.#timer,
+			anchorPartId: undefined, // Clear automatic anchor
+			estimateState,
+		}
+		this.#emitChange(this.#timer)
 	}
 }

--- a/packages/job-worker/src/blueprints/context/services/__tests__/TTimersService.test.ts
+++ b/packages/job-worker/src/blueprints/context/services/__tests__/TTimersService.test.ts
@@ -6,6 +6,11 @@ import type { RundownTTimer, RundownTTimerIndex } from '@sofie-automation/coreli
 import type { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { mock, MockProxy } from 'jest-mock-extended'
 import type { ReadonlyDeep } from 'type-fest'
+import type { JobContext } from '../../../../jobs/index.js'
+
+function createMockJobContext(): MockProxy<JobContext> {
+	return mock<JobContext>()
+}
 
 function createMockPlayoutModel(tTimers: [RundownTTimer, RundownTTimer, RundownTTimer]): MockProxy<PlayoutModel> {
 	const mockPlayoutModel = mock<PlayoutModel>()
@@ -42,8 +47,10 @@ describe('TTimersService', () => {
 		it('should create three timer instances', () => {
 			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(timers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(timers, updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(service.timers).toHaveLength(3)
 			expect(service.timers[0]).toBeInstanceOf(PlaylistTTimerImpl)
@@ -54,8 +61,9 @@ describe('TTimersService', () => {
 
 	it('from playout model', () => {
 		const mockPlayoutModel = createMockPlayoutModel(createEmptyTTimers())
+		const mockJobContext = createMockJobContext()
 
-		const service = TTimersService.withPlayoutModel(mockPlayoutModel)
+		const service = TTimersService.withPlayoutModel(mockPlayoutModel, mockJobContext)
 		expect(service.timers).toHaveLength(3)
 
 		const timer = service.getTimer(1)
@@ -71,8 +79,10 @@ describe('TTimersService', () => {
 		it('should return the correct timer for index 1', () => {
 			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(timers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(timers, updateFn, mockPlayoutModel, mockJobContext)
 
 			const timer = service.getTimer(1)
 
@@ -82,8 +92,10 @@ describe('TTimersService', () => {
 		it('should return the correct timer for index 2', () => {
 			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(timers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(timers, updateFn, mockPlayoutModel, mockJobContext)
 
 			const timer = service.getTimer(2)
 
@@ -93,8 +105,10 @@ describe('TTimersService', () => {
 		it('should return the correct timer for index 3', () => {
 			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(timers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(timers, updateFn, mockPlayoutModel, mockJobContext)
 
 			const timer = service.getTimer(3)
 
@@ -104,8 +118,10 @@ describe('TTimersService', () => {
 		it('should throw for invalid index', () => {
 			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(timers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(timers, updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(() => service.getTimer(0 as RundownTTimerIndex)).toThrow('T-timer index out of range: 0')
 			expect(() => service.getTimer(4 as RundownTTimerIndex)).toThrow('T-timer index out of range: 4')
@@ -120,10 +136,11 @@ describe('TTimersService', () => {
 			tTimers[1].mode = { type: 'countdown', duration: 60000, stopAtZero: true }
 			tTimers[1].state = { paused: false, zeroTime: 65000 }
 
-			const timers = createEmptyTTimers()
 			const updateFn = jest.fn()
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
 
-			const service = new TTimersService(timers, updateFn)
+			const service = new TTimersService(tTimers, updateFn, mockPlayoutModel, mockJobContext)
 
 			service.clearAllTimers()
 
@@ -149,7 +166,9 @@ describe('PlaylistTTimerImpl', () => {
 		it('should return the correct index', () => {
 			const tTimers = createEmptyTTimers()
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[1], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[1], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.index).toBe(2)
 		})
@@ -158,16 +177,19 @@ describe('PlaylistTTimerImpl', () => {
 			const tTimers = createEmptyTTimers()
 			tTimers[1].label = 'Custom Label'
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[1], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[1], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.label).toBe('Custom Label')
 		})
 
 		it('should return null state when no mode is set', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toBeNull()
 		})
@@ -177,7 +199,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: false, zeroTime: 15000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'freeRun',
@@ -191,7 +215,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: true, duration: 3000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'freeRun',
@@ -209,7 +235,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 15000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'countdown',
@@ -229,7 +257,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: true, duration: 2000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'countdown',
@@ -249,7 +279,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 20000 } // 10 seconds in the future
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'timeOfDay',
@@ -270,7 +302,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: targetTimestamp }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(timer.state).toEqual({
 				mode: 'timeOfDay',
@@ -285,9 +319,10 @@ describe('PlaylistTTimerImpl', () => {
 	describe('setLabel', () => {
 		it('should update the label', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.setLabel('New Label')
 
@@ -306,7 +341,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: false, zeroTime: 5000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.clearTimer()
 
@@ -322,9 +359,10 @@ describe('PlaylistTTimerImpl', () => {
 	describe('startCountdown', () => {
 		it('should start a running countdown with default options', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startCountdown(60000)
 
@@ -342,9 +380,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should start a paused countdown', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startCountdown(30000, { startPaused: true, stopAtZero: false })
 
@@ -364,9 +403,10 @@ describe('PlaylistTTimerImpl', () => {
 	describe('startFreeRun', () => {
 		it('should start a running free-run timer', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startFreeRun()
 
@@ -382,9 +422,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should start a paused free-run timer', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startFreeRun({ startPaused: true })
 
@@ -402,9 +443,10 @@ describe('PlaylistTTimerImpl', () => {
 	describe('startTimeOfDay', () => {
 		it('should start a timeOfDay timer with time string', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startTimeOfDay('15:30')
 
@@ -425,9 +467,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should start a timeOfDay timer with numeric timestamp', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 			const targetTimestamp = 1737331200000
 
 			timer.startTimeOfDay(targetTimestamp)
@@ -449,9 +492,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should start a timeOfDay timer with stopAtZero false', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startTimeOfDay('18:00', { stopAtZero: false })
 
@@ -472,9 +516,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should start a timeOfDay timer with 12-hour format', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			timer.startTimeOfDay('5:30pm')
 
@@ -495,18 +540,20 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should throw for invalid time string', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(() => timer.startTimeOfDay('invalid')).toThrow('Unable to parse target time for timeOfDay T-timer')
 		})
 
 		it('should throw for empty time string', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			expect(() => timer.startTimeOfDay('')).toThrow('Unable to parse target time for timeOfDay T-timer')
 		})
@@ -518,7 +565,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: false, zeroTime: 5000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.pause()
 
@@ -538,7 +587,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'countdown', duration: 60000, stopAtZero: true }
 			tTimers[0].state = { paused: false, zeroTime: 70000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.pause()
 
@@ -557,9 +608,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should return false for timer with no mode', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.pause()
 
@@ -576,7 +628,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 20000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.pause()
 
@@ -591,7 +645,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: true, duration: -3000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.resume()
 
@@ -611,7 +667,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: false, zeroTime: 5000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.resume()
 
@@ -622,9 +680,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should return false for timer with no mode', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.resume()
 
@@ -641,7 +700,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 20000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.resume()
 
@@ -656,7 +717,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'countdown', duration: 60000, stopAtZero: true }
 			tTimers[0].state = { paused: false, zeroTime: 40000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 
@@ -682,7 +745,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: true, duration: 15000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 
@@ -704,7 +769,9 @@ describe('PlaylistTTimerImpl', () => {
 			tTimers[0].mode = { type: 'freeRun' }
 			tTimers[0].state = { paused: false, zeroTime: 5000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 
@@ -721,7 +788,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 5000 } // old target time
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 
@@ -750,7 +819,9 @@ describe('PlaylistTTimerImpl', () => {
 			}
 			tTimers[0].state = { paused: false, zeroTime: 5000 }
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 
@@ -760,9 +831,10 @@ describe('PlaylistTTimerImpl', () => {
 
 		it('should return false for timer with no mode', () => {
 			const tTimers = createEmptyTTimers()
-
 			const updateFn = jest.fn()
-			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn)
+			const mockPlayoutModel = createMockPlayoutModel(tTimers)
+			const mockJobContext = createMockJobContext()
+			const timer = new PlaylistTTimerImpl(tTimers[0], updateFn, mockPlayoutModel, mockJobContext)
 
 			const result = timer.restart()
 

--- a/packages/job-worker/src/ingest/__tests__/syncChangesToPartInstance.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/syncChangesToPartInstance.test.ts
@@ -118,6 +118,9 @@ describe('SyncChangesToPartInstancesWorker', () => {
 				{
 					findPart: jest.fn(() => undefined),
 					getGlobalPieces: jest.fn(() => []),
+					getAllOrderedParts: jest.fn(() => []),
+					getOrderedSegments: jest.fn(() => []),
+					findAdlibPiece: jest.fn(() => undefined),
 				},
 				mockOptions
 			)

--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -130,6 +130,7 @@ export class SyncChangesToPartInstancesWorker {
 
 		const syncContext = new SyncIngestUpdateToPartInstanceContext(
 			this.#context,
+			this.#playoutModel,
 			{
 				name: `Update to ${existingPartInstance.partInstance.part.externalId}`,
 				identifier: `rundownId=${existingPartInstance.partInstance.part.rundownId},segmentId=${existingPartInstance.partInstance.part.segmentId}`,

--- a/packages/job-worker/src/playout/__tests__/tTimersJobs.test.ts
+++ b/packages/job-worker/src/playout/__tests__/tTimersJobs.test.ts
@@ -1,0 +1,211 @@
+import { setupDefaultJobEnvironment, MockJobContext } from '../../__mocks__/context.js'
+import { handleRecalculateTTimerEstimates } from '../tTimersJobs.js'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { literal } from '@sofie-automation/corelib/dist/lib'
+
+describe('tTimersJobs', () => {
+	let context: MockJobContext
+
+	beforeEach(() => {
+		context = setupDefaultJobEnvironment()
+	})
+
+	describe('handleRecalculateTTimerEstimates', () => {
+		it('should handle studio with active playlists', async () => {
+			// Create an active playlist
+			const playlistId = protectString<RundownPlaylistId>('playlist1')
+
+			await context.directCollections.RundownPlaylists.insertOne(
+				literal<DBRundownPlaylist>({
+					_id: playlistId,
+					externalId: 'test',
+					studioId: context.studioId,
+					name: 'Test Playlist',
+					created: 0,
+					modified: 0,
+					currentPartInfo: null,
+					nextPartInfo: null,
+					previousPartInfo: null,
+					rundownIdsInOrder: [],
+					timing: {
+						type: 'none' as any,
+					},
+					activationId: protectString('activation1'),
+					rehearsal: false,
+					holdState: undefined,
+					tTimers: [
+						{
+							index: 1,
+							label: 'Timer 1',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 2,
+							label: 'Timer 2',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 3,
+							label: 'Timer 3',
+							mode: null,
+							state: null,
+						},
+					],
+				})
+			)
+
+			// Should complete without errors
+			await expect(handleRecalculateTTimerEstimates(context)).resolves.toBeUndefined()
+		})
+
+		it('should handle studio with no active playlists', async () => {
+			// Create an inactive playlist
+			const playlistId = protectString<RundownPlaylistId>('playlist1')
+
+			await context.directCollections.RundownPlaylists.insertOne(
+				literal<DBRundownPlaylist>({
+					_id: playlistId,
+					externalId: 'test',
+					studioId: context.studioId,
+					name: 'Inactive Playlist',
+					created: 0,
+					modified: 0,
+					currentPartInfo: null,
+					nextPartInfo: null,
+					previousPartInfo: null,
+					rundownIdsInOrder: [],
+					timing: {
+						type: 'none' as any,
+					},
+					activationId: undefined, // Not active
+					rehearsal: false,
+					holdState: undefined,
+					tTimers: [
+						{
+							index: 1,
+							label: 'Timer 1',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 2,
+							label: 'Timer 2',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 3,
+							label: 'Timer 3',
+							mode: null,
+							state: null,
+						},
+					],
+				})
+			)
+
+			// Should complete without errors (just does nothing)
+			await expect(handleRecalculateTTimerEstimates(context)).resolves.toBeUndefined()
+		})
+
+		it('should handle multiple active playlists', async () => {
+			// Create multiple active playlists
+			const playlistId1 = protectString<RundownPlaylistId>('playlist1')
+			const playlistId2 = protectString<RundownPlaylistId>('playlist2')
+
+			await context.directCollections.RundownPlaylists.insertOne(
+				literal<DBRundownPlaylist>({
+					_id: playlistId1,
+					externalId: 'test1',
+					studioId: context.studioId,
+					name: 'Active Playlist 1',
+					created: 0,
+					modified: 0,
+					currentPartInfo: null,
+					nextPartInfo: null,
+					previousPartInfo: null,
+					rundownIdsInOrder: [],
+					timing: {
+						type: 'none' as any,
+					},
+					activationId: protectString('activation1'),
+					rehearsal: false,
+					holdState: undefined,
+					tTimers: [
+						{
+							index: 1,
+							label: 'Timer 1',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 2,
+							label: 'Timer 2',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 3,
+							label: 'Timer 3',
+							mode: null,
+							state: null,
+						},
+					],
+				})
+			)
+
+			await context.directCollections.RundownPlaylists.insertOne(
+				literal<DBRundownPlaylist>({
+					_id: playlistId2,
+					externalId: 'test2',
+					studioId: context.studioId,
+					name: 'Active Playlist 2',
+					created: 0,
+					modified: 0,
+					currentPartInfo: null,
+					nextPartInfo: null,
+					previousPartInfo: null,
+					rundownIdsInOrder: [],
+					timing: {
+						type: 'none' as any,
+					},
+					activationId: protectString('activation2'),
+					rehearsal: false,
+					holdState: undefined,
+					tTimers: [
+						{
+							index: 1,
+							label: 'Timer 1',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 2,
+							label: 'Timer 2',
+							mode: null,
+							state: null,
+						},
+						{
+							index: 3,
+							label: 'Timer 3',
+							mode: null,
+							state: null,
+						},
+					],
+				})
+			)
+
+			// Should complete without errors, processing both playlists
+			await expect(handleRecalculateTTimerEstimates(context)).resolves.toBeUndefined()
+		})
+
+		it('should handle playlist deleted between query and lock', async () => {
+			// This test is harder to set up properly, but the function should handle it
+			// by checking if playlist exists after acquiring lock
+			await expect(handleRecalculateTTimerEstimates(context)).resolves.toBeUndefined()
+		})
+	})
+})

--- a/packages/job-worker/src/playout/lookahead/util.ts
+++ b/packages/job-worker/src/playout/lookahead/util.ts
@@ -34,11 +34,16 @@ export function isPieceInstance(piece: Piece | PieceInstance | PieceInstancePiec
 
 /**
  * Excludes the previous, current and next part
+ * @param context Job context
+ * @param playoutModel The playout model
+ * @param partCount Maximum number of parts to return
+ * @param ignoreQuickLoop If true, ignores quickLoop markers and returns parts in linear order. Defaults to false for backwards compatibility.
  */
 export function getOrderedPartsAfterPlayhead(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	partCount: number
+	partCount: number,
+	ignoreQuickLoop: boolean = false
 ): ReadonlyDeep<DBPart>[] {
 	if (partCount <= 0) {
 		return []
@@ -66,7 +71,7 @@ export function getOrderedPartsAfterPlayhead(
 		null,
 		orderedSegments,
 		orderedParts,
-		{ ignoreUnplayable: true, ignoreQuickLoop: false }
+		{ ignoreUnplayable: true, ignoreQuickLoop }
 	)
 	if (!nextNextPart) {
 		// We don't know where to begin searching, so we can't do anything

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -33,6 +33,7 @@ import {
 import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { convertNoteToNotification } from '../notifications/util.js'
 import { PersistentPlayoutStateStore } from '../blueprints/context/services/PersistantStateStore.js'
+import { recalculateTTimerEstimates } from './tTimers.js'
 
 /**
  * Set or clear the nexted part, from a given PartInstance, or SelectNextPartResult
@@ -95,6 +96,9 @@ export async function setNextPart(
 	playoutModel.updateQuickLoopState()
 
 	await cleanupOrphanedItems(context, playoutModel)
+
+	// Recalculate T-Timer estimates based on the new next part
+	recalculateTTimerEstimates(context, playoutModel)
 
 	if (span) span.end()
 }

--- a/packages/job-worker/src/playout/tTimers.ts
+++ b/packages/job-worker/src/playout/tTimers.ts
@@ -4,9 +4,14 @@ import type {
 	RundownTTimer,
 	TimerState,
 } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import { literal } from '@sofie-automation/corelib/dist/lib'
 import { getCurrentTime } from '../lib/index.js'
 import type { ReadonlyDeep } from 'type-fest'
 import * as chrono from 'chrono-node'
+import { isPartPlayable } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { PartId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { JobContext } from '../jobs/index.js'
+import { PlayoutModel } from './model/PlayoutModel.js'
 
 export function validateTTimerIndex(index: number): asserts index is RundownTTimerIndex {
 	if (isNaN(index) || index < 1 || index > 3) throw new Error(`T-timer index out of range: ${index}`)
@@ -166,4 +171,143 @@ export function calculateNextTimeOfDayTarget(targetTime: string | number): numbe
 		forwardDate: true,
 	})
 	return parsed ? parsed.getTime() : null
+}
+
+/**
+ * Recalculate T-Timer estimates based on timing anchors
+ *
+ * For each T-Timer that has an anchorPartId set, this function:
+ * 1. Iterates through ordered parts from current/next onwards
+ * 2. Accumulates expected durations until the anchor part is reached
+ * 3. Updates estimateState with the calculated duration
+ * 4. Sets the estimate as running if we're progressing, or paused if pushing (overrunning)
+ *
+ * @param context Job context
+ * @param playoutModel The playout model containing the playlist and parts
+ */
+export function recalculateTTimerEstimates(context: JobContext, playoutModel: PlayoutModel): void {
+	const span = context.startSpan('recalculateTTimerEstimates')
+
+	const playlist = playoutModel.playlist
+	const tTimers = playlist.tTimers
+
+	// Find which timers have anchors that need calculation
+	const timerAnchors = new Map<PartId, RundownTTimerIndex[]>()
+	for (const timer of tTimers) {
+		if (timer.anchorPartId) {
+			const existingTimers = timerAnchors.get(timer.anchorPartId) ?? []
+			existingTimers.push(timer.index)
+			timerAnchors.set(timer.anchorPartId, existingTimers)
+		}
+	}
+
+	// If no timers have anchors, nothing to do
+	if (timerAnchors.size === 0) {
+		if (span) span.end()
+		return
+	}
+
+	const currentPartInstance = playoutModel.currentPartInstance?.partInstance
+	const nextPartInstance = playoutModel.nextPartInstance?.partInstance
+
+	// Get ordered parts to iterate through
+	const orderedParts = playoutModel.getAllOrderedParts()
+
+	// Start from next part if available, otherwise current, otherwise first playable part
+	let startPartIndex: number | undefined
+	if (nextPartInstance) {
+		// We have a next part selected, start from there
+		startPartIndex = orderedParts.findIndex((p) => p._id === nextPartInstance.part._id)
+	} else if (currentPartInstance) {
+		// No next, but we have current - start from the part after current
+		const currentIndex = orderedParts.findIndex((p) => p._id === currentPartInstance.part._id)
+		if (currentIndex >= 0 && currentIndex < orderedParts.length - 1) {
+			startPartIndex = currentIndex + 1
+		}
+	}
+
+	// If we couldn't find a starting point, start from the first playable part
+	startPartIndex ??= orderedParts.findIndex((p) => isPartPlayable(p))
+
+	if (startPartIndex === undefined || startPartIndex < 0) {
+		// No parts to iterate through, clear estimates
+		for (const timer of tTimers) {
+			if (timer.anchorPartId) {
+				playoutModel.updateTTimer({ ...timer, estimateState: undefined })
+			}
+		}
+		if (span) span.end()
+		return
+	}
+
+	// Iterate through parts and accumulate durations
+	const playablePartsSlice = orderedParts.slice(startPartIndex).filter((p) => isPartPlayable(p))
+
+	const now = getCurrentTime()
+	let accumulatedDuration = 0
+
+	// Calculate remaining time for current part
+	// If not started, treat as if it starts now (elapsed = 0, remaining = full duration)
+	// Account for playOffset (e.g., from play-from-anywhere feature)
+	let isPushing = false
+	if (currentPartInstance) {
+		const currentPartDuration =
+			currentPartInstance.part.expectedDurationWithTransition ?? currentPartInstance.part.expectedDuration
+		if (currentPartDuration) {
+			const currentPartStartedPlayback = currentPartInstance.timings?.plannedStartedPlayback
+			const startedPlayback =
+				currentPartStartedPlayback && currentPartStartedPlayback <= now ? currentPartStartedPlayback : now
+			const playOffset = currentPartInstance.timings?.playOffset || 0
+			const elapsed = now - startedPlayback - playOffset
+			const remaining = currentPartDuration - elapsed
+
+			isPushing = remaining < 0
+			accumulatedDuration = Math.max(0, remaining)
+		}
+	}
+
+	for (const part of playablePartsSlice) {
+		// Add this part's expected duration to the accumulator
+		const partDuration = part.expectedDurationWithTransition ?? part.expectedDuration ?? 0
+		accumulatedDuration += partDuration
+
+		// Check if this part is an anchor for any timer
+		const timersForThisPart = timerAnchors.get(part._id)
+		if (timersForThisPart) {
+			for (const timerIndex of timersForThisPart) {
+				const timer = tTimers[timerIndex - 1]
+
+				// Update the timer's estimate
+				const estimateState: TimerState = isPushing
+					? literal<TimerState>({
+							paused: true,
+							duration: accumulatedDuration,
+						})
+					: literal<TimerState>({
+							paused: false,
+							zeroTime: now + accumulatedDuration,
+						})
+
+				playoutModel.updateTTimer({ ...timer, estimateState })
+			}
+			// Remove this anchor since we've processed it
+			timerAnchors.delete(part._id)
+		}
+
+		// Early exit if we've resolved all timers
+		if (timerAnchors.size === 0) {
+			break
+		}
+	}
+
+	// Clear estimates for any timers whose anchors weren't found (e.g., anchor is in the past or removed)
+	// Any remaining entries in timerAnchors are anchors that weren't reached
+	for (const timerIndices of timerAnchors.values()) {
+		for (const timerIndex of timerIndices) {
+			const timer = tTimers[timerIndex - 1]
+			playoutModel.updateTTimer({ ...timer, estimateState: undefined })
+		}
+	}
+
+	if (span) span.end()
 }

--- a/packages/job-worker/src/playout/tTimers.ts
+++ b/packages/job-worker/src/playout/tTimers.ts
@@ -301,6 +301,9 @@ export function recalculateTTimerEstimates(context: JobContext, playoutModel: Pl
 		}
 	}
 
+	// Save remaining current part time for pauseTime calculation
+	const currentPartRemainingTime = totalAccumulator
+
 	// Single pass through parts
 	for (const part of playablePartsSlice) {
 		// Detect segment boundary
@@ -335,10 +338,12 @@ export function recalculateTTimerEstimates(context: JobContext, playoutModel: Pl
 					? literal<TimerState>({
 							paused: true,
 							duration: anchorTime,
+							pauseTime: null, // Already paused/pushing
 						})
 					: literal<TimerState>({
 							paused: false,
 							zeroTime: now + anchorTime,
+							pauseTime: now + currentPartRemainingTime, // When current part ends and pushing begins
 						})
 
 				playoutModel.updateTTimer({ ...timer, estimateState })

--- a/packages/job-worker/src/playout/tTimers.ts
+++ b/packages/job-worker/src/playout/tTimers.ts
@@ -8,19 +8,10 @@ import { literal } from '@sofie-automation/corelib/dist/lib'
 import { getCurrentTime } from '../lib/index.js'
 import type { ReadonlyDeep } from 'type-fest'
 import * as chrono from 'chrono-node'
-import { PartId, SegmentId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PartId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { JobContext } from '../jobs/index.js'
 import { PlayoutModel } from './model/PlayoutModel.js'
-import { StudioJobs } from '@sofie-automation/corelib/dist/worker/studio'
-import { logger } from '../logging.js'
-import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyError'
 import { getOrderedPartsAfterPlayhead } from './lookahead/util.js'
-
-/**
- * Map of active setTimeout timeouts by studioId
- * Used to clear previous timeout when recalculation is triggered before the timeout fires
- */
-const activeTimeouts = new Map<StudioId, NodeJS.Timeout>()
 
 export function validateTTimerIndex(index: number): asserts index is RundownTTimerIndex {
 	if (isNaN(index) || index < 1 || index > 3) throw new Error(`T-timer index out of range: ${index}`)
@@ -203,13 +194,6 @@ export function recalculateTTimerEstimates(context: JobContext, playoutModel: Pl
 
 	const playlist = playoutModel.playlist
 
-	// Clear any existing timeout for this studio
-	const existingTimeout = activeTimeouts.get(playlist.studioId)
-	if (existingTimeout) {
-		clearTimeout(existingTimeout)
-		activeTimeouts.delete(playlist.studioId)
-	}
-
 	const tTimers = playlist.tTimers
 
 	// Find which timers have anchors that need calculation
@@ -287,17 +271,6 @@ export function recalculateTTimerEstimates(context: JobContext, playoutModel: Pl
 			} else {
 				totalAccumulator = currentSegmentBudget
 			}
-		}
-
-		// Schedule next recalculation
-		if (!isPushing && !currentPartInstance.part.autoNext) {
-			const delay = totalAccumulator + 5
-			const timeoutId = setTimeout(() => {
-				context.queueStudioJob(StudioJobs.RecalculateTTimerEstimates, undefined, undefined).catch((err) => {
-					logger.error(`Failed to queue T-Timer recalculation: ${stringifyError(err)}`)
-				})
-			}, delay)
-			activeTimeouts.set(playlist.studioId, timeoutId)
 		}
 	}
 

--- a/packages/job-worker/src/playout/tTimersJobs.ts
+++ b/packages/job-worker/src/playout/tTimersJobs.ts
@@ -1,0 +1,44 @@
+import { JobContext } from '../jobs/index.js'
+import { recalculateTTimerEstimates } from './tTimers.js'
+import { runWithPlayoutModel, runWithPlaylistLock } from './lock.js'
+
+/**
+ * Handle RecalculateTTimerEstimates job
+ * This is called after setNext, takes, and ingest changes to update T-Timer estimates
+ * Since this job doesn't take a playlistId parameter, it finds the active playlist in the studio
+ */
+export async function handleRecalculateTTimerEstimates(context: JobContext): Promise<void> {
+	// Find active playlists in this studio (projection to just get IDs)
+	const activePlaylistIds = await context.directCollections.RundownPlaylists.findFetch(
+		{
+			studioId: context.studioId,
+			activationId: { $exists: true },
+		},
+		{
+			projection: {
+				_id: 1,
+			},
+		}
+	)
+
+	if (activePlaylistIds.length === 0) {
+		// No active playlist, nothing to do
+		return
+	}
+
+	// Process each active playlist (typically there's only one)
+	for (const playlistRef of activePlaylistIds) {
+		await runWithPlaylistLock(context, playlistRef._id, async (lock) => {
+			// Fetch the full playlist object
+			const playlist = await context.directCollections.RundownPlaylists.findOne(playlistRef._id)
+			if (!playlist) {
+				// Playlist was removed between query and lock
+				return
+			}
+
+			await runWithPlayoutModel(context, playlist, lock, null, async (playoutModel) => {
+				recalculateTTimerEstimates(context, playoutModel)
+			})
+		})
+	}
+}

--- a/packages/job-worker/src/workers/studio/jobs.ts
+++ b/packages/job-worker/src/workers/studio/jobs.ts
@@ -49,6 +49,7 @@ import { handleActivateAdlibTesting } from '../../playout/adlibTesting.js'
 import { handleExecuteBucketAdLibOrAction } from '../../playout/bucketAdlibJobs.js'
 import { handleSwitchRouteSet } from '../../studio/routeSet.js'
 import { handleCleanupOrphanedExpectedPackageReferences } from '../../playout/expectedPackages.js'
+import { handleRecalculateTTimerEstimates } from '../../playout/tTimersJobs.js'
 
 type ExecutableFunction<T extends keyof StudioJobFunc> = (
 	context: JobContext,
@@ -86,6 +87,8 @@ export const studioJobHandlers: StudioJobHandlers = {
 
 	[StudioJobs.OnPlayoutPlaybackChanged]: handleOnPlayoutPlaybackChanged,
 	[StudioJobs.OnTimelineTriggerTime]: handleTimelineTriggerTime,
+
+	[StudioJobs.RecalculateTTimerEstimates]: handleRecalculateTTimerEstimates,
 
 	[StudioJobs.UpdateStudioBaseline]: handleUpdateStudioBaseline,
 	[StudioJobs.CleanupEmptyPlaylists]: handleRemoveEmptyPlaylists,


### PR DESCRIPTION
## About the Contributor

This pull request is posted by SuperflyTV on behalf of the BBC.

## Type of Contribution

This is a Feature

## Current Behavior

When a part starts "pushing" and progress through the timeline is paused, the T-Timer estimateState is set to paused on the server and the update is propogated to the clients through the database and meteors standard methods.

## New Behavior

Information about when pushing will start and therefore a pause is needed, is included in the estimateState, so the client is able to pause itself, and no update needs to be sent. The pauseTime is a time of day, not a duration. The remaining duration is therefore `zeroTime - pauseTime`.

This also means a regular T-Timer can have a pause time if you know that you want to hold the clock at a certain point in the future. If you set `zeroTime` and `pauseTime` to the same value, the clock will stop at zero, so we could maybe remove the stopAtZero feature.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
